### PR TITLE
Migrate the "Using the WN Client" document

### DIFF
--- a/docs/archive/UsingWorkerNodeClient
+++ b/docs/archive/UsingWorkerNodeClient
@@ -1,0 +1,240 @@
+---+!! *<nop>%SPACEOUT{ "%TOPIC%" }%*
+%DOC_STATUS_TABLE%
+%TOC%
+
+<!-- conventions used in this document
+   * Local UCL_HOST = %URLPARAM{"INPUT_HOST" encode="quote" default="client"}%
+   * Local UCL_USER = %URLPARAM{"INPUT_USER" encode="quote" default="user"}%
+   * Local UCL_DOMAIN = %URLPARAM{"INPUT_DOMAIN" encode="quote" default="opensciencegrid.org"}%
+   * Set TWISTY_OPTS_DETAILED = mode="div" showlink="Show Detailed Output" hidelink="Hide" showimgleft="/twiki/pub/TWiki/TWikiDocGraphics/toggleopen-small.gif" hideimgleft="/twiki/pub/TWiki/TWikiDocGraphics/toggleclose-small.gif" remember="on" start="hide" 
+-->
+
+---+ Introduction
+
+The Worker Node Client is a collection of useful software components that is guaranteed to be on every OSG worker node. In addition, a job running on a worker node can access a handful of environment variables that your job can use to locate handy resources.
+
+This page describes how to initialize the environment of your job to correctly access the execution and data areas from the worker node.
+
+The OSG provides no scientific software dependencies or software build tools on the worker node; you are expected to bring along all application-level dependencies yourself. Sites are not required to provide any specific tools (gcc, svn, lapack, blas, etc.) beyond the ones in the OSG worker node client. 
+
+
+---+ The Environment
+
+All OSG sites should be configured so that the Worker Node Client software is in the default environment of the job and some variables are already defined when your job starts running.
+
+%TWISTY{%TWISTY_OPTS_DETAILED% showlink="Click to show the output from a test run of a job with the envisonment configured correctly"}% <pre class="screen">
+%UCL_PROMPT% globus-job-run red.unl.edu:/jobmanager-condor /usr/bin/printenv
+_CONDOR_ANCESTOR_10629=11149:1288983808:3570854656
+OSG_GLEXEC_LOCATION=/usr/sbin/glexec
+CHANGED_X509=/grid_home/uscmsPool018/.globus/job/red.unl.edu/2556.1288983706/x509_up
+GLOBUS_LOCATION=/opt/osg/osg-wn-source/globus
+TMPDIR=/scratch/condor/var/lib/condor/execute/dir_10629
+_CONDOR_SCRATCH_DIR=/scratch/condor/var/lib/condor/execute/dir_10629
+OLDPWD=/scratch/condor/var/lib/condor/execute/dir_10629
+OSG_WN_TMP=/scratch/condor/var/lib/condor/execute/dir_10629
+OSG_SQUID_LOCATION=red-squid1.unl.edu:3128
+OSG_JOB_CONTACT=red.unl.edu/jobmanager-condor
+OSG_SITE_WRITE=UNAVAILABLE
+TEMP=/scratch/condor/var/lib/condor/execute/dir_10629
+LD_LIBRARY_PATH=/opt/osg/osg-1.2/subversion/lib:/opt/osg/osg-1.2/apache/lib:/opt/osg/osg-1.2/MonaLisa/Service/VDTFarm/pgsql/lib:/opt/osg/osg-1.2/prima/lib:/opt/osg/osg-1.2/curl/lib:/opt/osg/osg-1.2/glite/lib64:/opt/osg/osg-1.2/glite/lib:/opt/osg/osg-1.2/mysql5/lib/mysql:/opt/osg/osg-1.2/jdk1.6/jre/lib/i386:/opt/osg/osg-1.2/jdk1.6/jre/lib/i386/server:/opt/osg/osg-1.2/jdk1.6/jre/lib/i386/client:/opt/osg/osg-1.2/berkeley-db/lib:/opt/osg/osg-1.2/expat/lib:/opt/osg/osg-1.2/globus/lib:/opt/osg/osg-1.2/subversion/lib:/opt/osg/osg-1.2/apache/lib:/opt/osg/osg-1.2/MonaLisa/Service/VDTFarm/pgsql/lib:/opt/osg/osg-1.2/prima/lib:/opt/osg/osg-1.2/curl/lib:/opt/osg/osg-1.2/glite/lib64:/opt/osg/osg-1.2/glite/lib:/opt/osg/osg-1.2/mysql5/lib/mysql:/opt/osg/osg-1.2/jdk1.6/jre/lib/i386:/opt/osg/osg-1.2/jdk1.6/jre/lib/i386/server:/opt/osg/osg-1.2/jdk1.6/jre/lib/i386/client:/opt/osg/osg-1.2/berkeley-db/lib:/opt/osg/osg-1.2/expat/lib:/opt/osg/osg-1.2/subversion/lib:/opt/osg/osg-1.2/apache/lib:/opt/osg/osg-1.2/MonaLisa/Service/VDTFarm/pgsql/lib:/opt/osg/osg-1.2/glite/lib64:/opt/osg/osg-1.2/glite/lib:/opt/osg/osg-1.2/prima/lib:/opt/osg/osg-1.2/mysql5/lib/mysql:/opt/osg/osg-1.2/berkeley-db/lib:/opt/osg/osg-1.2/expat/lib::
+OSG_LOCATION=/opt/osg/osg-1.2
+OSG_SITE_READ=UNAVAILABLE
+_CONDOR_ANCESTOR_4198=4208:1284756786:1513536384
+GLOBUS_GRAM_MYJOB_CONTACT=URLx-nexus://red.unl.edu:60265/
+MY_INITIAL_DIR=$_CONDOR_SCRATCH_DIR
+OSG_DATA=/opt/osg/data
+PWD=/scratch/condor/var/lib/condor/execute/dir_10629
+OSG_APP=/opt/osg/app
+_CONDOR_WRAPPER_ERROR_FILE=/scratch/condor/var/lib/condor/execute/dir_10629/.job_wrapper_failure
+_CONDOR_SLOT=7
+OSG_GRID=/opt/osg/osg-wn-source
+OSG_HOSTNAME=red.unl.edu
+SHLVL=0
+HOME=/grid_home/uscmsPool018
+_CONDOR_MACHINE_AD=/scratch/condor/var/lib/condor/execute/dir_10629/.machine.ad
+OSG_STORAGE_ELEMENT=True
+X509_USER_PROXY=/scratch/condor/var/lib/condor/execute/dir_10629/x509_up
+OSG_DEFAULT_SE=srm.unl.edu
+LOGNAME=uscmsPool018
+TMP=/scratch/condor/var/lib/condor/execute/dir_10629
+OSG_SITE_NAME=Nebraska
+_CONDOR_ANCESTOR_4208=10629:1288983806:3772562235
+_CONDOR_JOB_AD=/scratch/condor/var/lib/condor/execute/dir_10629/.job.ad
+GLOBUS_GRAM_JOB_CONTACT=https://red.unl.edu:32943/2556/1288983706/
+</pre>
+%ENDTWISTY%
+
+---+ Common software available on worker nodes.
+
+The OSG worker node client (called the =wn-client= package) contains the following software:
+
+   * The site's supported set of CA certificates (located in $X509_CERT_DIR after the environment is set up)
+   * Proxy management tools:
+      * Create proxies: =voms-proxy-init= and =grid-proxy-init=
+      * Show proxy info: =voms-proxy-info= and =grid-proxy-info=
+      * Destroy the current proxy: =voms-proxy-destroy= and =grid-proxy-destroy=
+   * Data transfer tools:
+      * HTTP/plain FTP protocol tools (via system dependencies):
+         * =wget= and =curl=: standard tools for downloading files with HTTP and FTP
+      * SRM clients
+         * LCG SRM Client (=lcg-cp= and others)
+         * LBNL SRM Client (=srm-copy= and others)
+         * FNAL SRM Client (=srmcp= and others)
+      * !GridFTP client
+         * Globus !GridFTP client (=globus-url-copy=)
+         * !UberFTP, another command-line client for !GridFTP; covers a wider variety of the !GridFTP protocol than just copying
+      * Site-specific protocols
+         * DCache client: =dccp=, a client specifically for sites running !dCache, on about 5–10 of the 80 OSG sites
+   * !MyProxy client tools
+
+Advanced users can list the content of the RPM
+
+
+---+ Directories in the Worker Node Environment
+
+The following table outlines the various important directories for the worker node environment. A job running on an OSG worker node can refer to each directory using the corresponding environment variable.
+
+%EDITTABLE{ header="| *Environment Variable* | *Purpose of a directory* | *Notes* |" format="| text | textarea, 2x30 | textarea, 2x30 |" changerows="on" }%
+| *Environment Variable* | *Purpose of a directory* | *Notes* |
+| =$OSG_APP= | Location for users to install software. | This directory is used by VO's to install software that will be used when running on the cluster.  For example, a VO may install the BLAST executable here.  The VO would submit jobs that executed the blast executable.  Access to this area varies from site-to-site.  Most sites allow software installation only from the head node (jobmanager-fork), while others require you to access it via a special job description of VOMS role. |
+| =$OSG_DATA= | Data files that are accessible via NFS from all batch slots, read-write. | %RED% Not all OSG sites have deployed this area. %ENDCOLOR%  You can test for existance by comparing the environment variable =$OSG_DATA= to =UNAVAILABLE=.  If true, then the directory is not available. |
+| =$OSG_WN_TMP= | Temporary storage area in which your job(s) run | Local to each batch slot.  Create a directory under this as your work area.  See NOTE below. |
+
+%NOTE% Be careful with using =$OSG_WN_TMP=, this  directory might be shared with other VOs.  We recommend the following code (suppose =gpn= is your VO's name):
+
+<pre class="screen">
+mkdir -p $OSG_WN_TMP/gpn
+export mydir=`mktemp -d -t gpn`
+cd $mydir
+# Run the rest of your application
+rm -rf $mydir
+</pre>
+
+A significant number of sites use the batch system to make an independent directory for each user job, and change =$OSG_WN_TMP= on the fly to point to this directory.
+
+There is no way to know in advance how much scratch disk space any given worker node has available, as OSG information systems don't advertise this.  Most of the times, it is shared among a number of job slots.
+
+<!--
+---+!! Input and Output Files Specified Via Condor-G
+
+Condor-G has the following attributes related to file transfers and your jobs:
+
+| =executable= | one file |
+| =output= | one file - stdout | 
+| =error= | one file - stderr |
+| =transfer_input_files= | comma separated list of files |
+| =transfer_output_files= | comma separated list of files |
+
+Do not use =transfer_input_files= or =transfer_output_files= to transfer more than a few megabytes: These files are transfered via the CE headnode and can cause serious loads, which can bring down the cluster.  Space on the headnode also tends to be limited, especially because some sites place a very small quota on your home directory. To transfer large files, we recommend pre-staging as covered by [[Storage/WebHome#Storage_for_the_End_User][the OSG-Storage documentation]].
+
+-->
+
+<!--
+---+!! Finding your way around
+
+%NOTE% A definition of the concepts used in this document can be found in [[Trash.ReleaseDocumentationLocalStorageConfiguration][Local Storage Configuration]], including a section describing minimal requirements and some sample configurations.
+
+Here we describe how to find the various storage locations. We start by describing how to find things after your job starts, and then complete the discussion by describing what you can determine from the outside, before you submit a job to the site. We deliberately do not describe what these various storage implementations are. That is done in the [[Trash.ReleaseDocumentationLocalStorageConfiguration][Local Storage Configuration]] document.
+
+
+
+
+<br/>
+
+See the [[Trash.ReleaseDocumentationComputeElementInstall][CE Install Guide]] and [[Trash.ReleaseDocumentationLocalStorageConfiguration][Local Storage Configuration]] for more information. 
+
+---++!! Getting information about CE storage before you submit a job
+
+You can retrieve the storage information for some sites by querying the OSG information services. We do not recommend using this method — instead, have the job discover the correct directory through its environment. This will not work reliably at all sites.
+
+We will illustrate this below using !ReSS.
+
+%TWISTY{
+mode="div"
+showlink="Show unrecommended query method..."
+hidelink="Hide queries"
+showimgleft="%ICONURLPATH{toggleopen-small}%"
+hideimgleft="%ICONURLPATH{toggleclose-small}%"
+}%
+The following query looks for storage directories for sites that support CMS (change "VO:cms" with the name of your VO):
+<pre class="screen">
+<userinput>condor_status -pool osg-ress-1.fnal.gov -const 'stringListIMember("VO:cms", GlueCEAccessControlBaseRule)' -format 'CE: %s ' GlueCEUniqueID -format 'OSG_WN_SCRATCH: %s ' GlueSubClusterWNTmpDir -format 'OSG_DATA: %s ' GlueCEInfoDataDir -format 'OSG_APP: %s\n' GlueCEInfoApplicationDir | sort | uniq</userinput>
+</pre>
+The reason the query is so long is due to the extensive format strings.  The above query shows the scratch, app, and data directories - one line per CE.  Here's a few lines of output:
+<pre class="screen">
+CE: antaeus.hpcc.ttu.edu:2119/jobmanager-sge-cms Scratch: /state/partition1 OSG_DATA: /lustre/hep/osg OSG_APP: /lustre/home/antaeus/apps
+CE: antaeus.hpcc.ttu.edu:2119/jobmanager-sge-serial Scratch: /state/partition1 OSG_DATA: /lustre/hep/osg OSG_APP: /lustre/home/antaeus/apps
+CE: belhaven-1.renci.org:2119/jobmanager-condor-default Scratch: /condor/osg_wn_tmp OSG_DATA: /nfs/osg-data OSG_APP: /nfs/osg-app
+CE: ce01.cmsaf.mit.edu:2119/jobmanager-condor-group_cmshi Scratch: /osg/tmp OSG_DATA: /osg/data OSG_APP: /osg/app
+CE: ce01.cmsaf.mit.edu:2119/jobmanager-condor-group_cmsprod Scratch: /osg/tmp OSG_DATA: /osg/data OSG_APP: /osg/app
+CE: ce01.cmsaf.mit.edu:2119/jobmanager-condor-group_cmsuser Scratch: /osg/tmp OSG_DATA: /osg/data OSG_APP: /osg/app
+CE: ce01.cmsaf.mit.edu:2119/jobmanager-condor-group_monitor Scratch: /osg/tmp OSG_DATA: /osg/data OSG_APP: /osg/app
+CE: cit-gatekeeper2.ultralight.org:2119/jobmanager-condor-cms_monitor Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
+CE: cit-gatekeeper2.ultralight.org:2119/jobmanager-condor-cms_priority Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
+CE: cit-gatekeeper2.ultralight.org:2119/jobmanager-condor-cms_production Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
+CE: cit-gatekeeper2.ultralight.org:2119/jobmanager-condor-cms_user Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
+CE: cit-gatekeeper.ultralight.org:2119/jobmanager-condor-cms_monitor Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
+CE: cit-gatekeeper.ultralight.org:2119/jobmanager-condor-cms_priority Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
+CE: cit-gatekeeper.ultralight.org:2119/jobmanager-condor-cms_production Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
+CE: cit-gatekeeper.ultralight.org:2119/jobmanager-condor-cms_user Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
+CE: cms-0.mps.ohio-state.edu:2119/jobmanager-condor-default Scratch: /hadoop/tmp OSG_DATA: /data/se/osg OSG_APP: /sharesoft/osg/app
+</pre>
+
+%ENDTWISTY%
+
+---+ Comments
+%COMMENT{type="tableappend"}%
+
+<!-- CONTENT MANAGEMENT PROJECT
+############################################################################################################
+ DEAR DOCUMENT OWNER
+ ===================
+
+ Thank you for claiming ownership for this document! Please fill in your FirstLast name here:
+   * Local OWNER             = MarcoMambelli
+
+ Please define the document area, choose one of the defined areas from the next line
+ DOC_AREA = (ComputeElement|Storage|VO|Security|User|Monitoring|General|Trash/Trash/Integration|Operations|Tier3)
+   * Local DOC_AREA       = User
+
+ define the primary role the document serves, choose one of the defined roles from the next line
+ DOC_ROLE = (EndUser|Student|Developer|SysAdmin|VOManager)
+   * Local DOC_ROLE       = Scientist
+
+ Please define the document type, choose one of the defined types from the next line
+ DOC_TYPE = (Troubleshooting|Training|Installation|HowTo|Planning|Navigation|Knowledge)
+   * Local DOC_TYPE       = Training
+  Please define if this document in general needs to be reviewed before release ( %YES% | %NO% )
+   * Local INCLUDE_REVIEW = %YES%
+
+ Please define if this document in general needs to be tested before release ( %YES% | %NO% )
+   * Local INCLUDE_TEST   = %YES%
+
+ change to %YES% once the document is ready to be reviewed and back to %NO% if that is not the case
+   * Local REVIEW_READY   = %YES%
+
+ change to %YES% once the document is ready to be tested and back to %NO% if that is not the case
+   * Local TEST_READY     = %YES%
+
+ change to %YES% only if the document has passed the review and the test (if applicable) and is ready for release
+   * Local RELEASE_READY  = %YES%
+
+
+ DEAR DOCUMENT REVIEWER
+ ======================
+
+ Thank for reviewing this document! Please fill in your FirstLast name here:
+   * Local REVIEWER       = JamesWeichel 
+ Please define the review status for this document to be in progress ( %IN_PROGRESS% ), failed ( %NO% ) or passed ( %YES% )
+   * Local REVIEW_PASSED  = %YES%
+
+
+ DEAR DOCUMENT TESTER
+ ====================
+
+ Thank for testing this document! Please fill in your FirstLast name here:
+   * Local TESTER         = MarcoMambelli 
+ Please define the test status for this document to be in progress ( %IN_PROGRESS% ), failed ( %NO% ) or passed ( %YES% )
+   * Local TEST_PASSED    = %YES%
+############################################################################################################
+-->

--- a/docs/archive/UsingWorkerNodeClient
+++ b/docs/archive/UsingWorkerNodeClient
@@ -1,14 +1,3 @@
----+!! *<nop>%SPACEOUT{ "%TOPIC%" }%*
-%DOC_STATUS_TABLE%
-%TOC%
-
-<!-- conventions used in this document
-   * Local UCL_HOST = %URLPARAM{"INPUT_HOST" encode="quote" default="client"}%
-   * Local UCL_USER = %URLPARAM{"INPUT_USER" encode="quote" default="user"}%
-   * Local UCL_DOMAIN = %URLPARAM{"INPUT_DOMAIN" encode="quote" default="opensciencegrid.org"}%
-   * Set TWISTY_OPTS_DETAILED = mode="div" showlink="Show Detailed Output" hidelink="Hide" showimgleft="/twiki/pub/TWiki/TWikiDocGraphics/toggleopen-small.gif" hideimgleft="/twiki/pub/TWiki/TWikiDocGraphics/toggleclose-small.gif" remember="on" start="hide" 
--->
-
 ---+ Introduction
 
 The Worker Node Client is a collection of useful software components that is guaranteed to be on every OSG worker node. In addition, a job running on a worker node can access a handful of environment variables that your job can use to locate handy resources.
@@ -22,7 +11,7 @@ The OSG provides no scientific software dependencies or software build tools on 
 
 All OSG sites should be configured so that the Worker Node Client software is in the default environment of the job and some variables are already defined when your job starts running.
 
-%TWISTY{%TWISTY_OPTS_DETAILED% showlink="Click to show the output from a test run of a job with the envisonment configured correctly"}% <pre class="screen">
+<pre>
 %UCL_PROMPT% globus-job-run red.unl.edu:/jobmanager-condor /usr/bin/printenv
 _CONDOR_ANCESTOR_10629=11149:1288983808:3570854656
 OSG_GLEXEC_LOCATION=/usr/sbin/glexec
@@ -62,7 +51,6 @@ _CONDOR_ANCESTOR_4208=10629:1288983806:3772562235
 _CONDOR_JOB_AD=/scratch/condor/var/lib/condor/execute/dir_10629/.job.ad
 GLOBUS_GRAM_JOB_CONTACT=https://red.unl.edu:32943/2556/1288983706/
 </pre>
-%ENDTWISTY%
 
 ---+ Common software available on worker nodes.
 
@@ -114,127 +102,3 @@ A significant number of sites use the batch system to make an independent direct
 
 There is no way to know in advance how much scratch disk space any given worker node has available, as OSG information systems don't advertise this.  Most of the times, it is shared among a number of job slots.
 
-<!--
----+!! Input and Output Files Specified Via Condor-G
-
-Condor-G has the following attributes related to file transfers and your jobs:
-
-| =executable= | one file |
-| =output= | one file - stdout | 
-| =error= | one file - stderr |
-| =transfer_input_files= | comma separated list of files |
-| =transfer_output_files= | comma separated list of files |
-
-Do not use =transfer_input_files= or =transfer_output_files= to transfer more than a few megabytes: These files are transfered via the CE headnode and can cause serious loads, which can bring down the cluster.  Space on the headnode also tends to be limited, especially because some sites place a very small quota on your home directory. To transfer large files, we recommend pre-staging as covered by [[Storage/WebHome#Storage_for_the_End_User][the OSG-Storage documentation]].
-
--->
-
-<!--
----+!! Finding your way around
-
-%NOTE% A definition of the concepts used in this document can be found in [[Trash.ReleaseDocumentationLocalStorageConfiguration][Local Storage Configuration]], including a section describing minimal requirements and some sample configurations.
-
-Here we describe how to find the various storage locations. We start by describing how to find things after your job starts, and then complete the discussion by describing what you can determine from the outside, before you submit a job to the site. We deliberately do not describe what these various storage implementations are. That is done in the [[Trash.ReleaseDocumentationLocalStorageConfiguration][Local Storage Configuration]] document.
-
-
-
-
-<br/>
-
-See the [[Trash.ReleaseDocumentationComputeElementInstall][CE Install Guide]] and [[Trash.ReleaseDocumentationLocalStorageConfiguration][Local Storage Configuration]] for more information. 
-
----++!! Getting information about CE storage before you submit a job
-
-You can retrieve the storage information for some sites by querying the OSG information services. We do not recommend using this method — instead, have the job discover the correct directory through its environment. This will not work reliably at all sites.
-
-We will illustrate this below using !ReSS.
-
-%TWISTY{
-mode="div"
-showlink="Show unrecommended query method..."
-hidelink="Hide queries"
-showimgleft="%ICONURLPATH{toggleopen-small}%"
-hideimgleft="%ICONURLPATH{toggleclose-small}%"
-}%
-The following query looks for storage directories for sites that support CMS (change "VO:cms" with the name of your VO):
-<pre class="screen">
-<userinput>condor_status -pool osg-ress-1.fnal.gov -const 'stringListIMember("VO:cms", GlueCEAccessControlBaseRule)' -format 'CE: %s ' GlueCEUniqueID -format 'OSG_WN_SCRATCH: %s ' GlueSubClusterWNTmpDir -format 'OSG_DATA: %s ' GlueCEInfoDataDir -format 'OSG_APP: %s\n' GlueCEInfoApplicationDir | sort | uniq</userinput>
-</pre>
-The reason the query is so long is due to the extensive format strings.  The above query shows the scratch, app, and data directories - one line per CE.  Here's a few lines of output:
-<pre class="screen">
-CE: antaeus.hpcc.ttu.edu:2119/jobmanager-sge-cms Scratch: /state/partition1 OSG_DATA: /lustre/hep/osg OSG_APP: /lustre/home/antaeus/apps
-CE: antaeus.hpcc.ttu.edu:2119/jobmanager-sge-serial Scratch: /state/partition1 OSG_DATA: /lustre/hep/osg OSG_APP: /lustre/home/antaeus/apps
-CE: belhaven-1.renci.org:2119/jobmanager-condor-default Scratch: /condor/osg_wn_tmp OSG_DATA: /nfs/osg-data OSG_APP: /nfs/osg-app
-CE: ce01.cmsaf.mit.edu:2119/jobmanager-condor-group_cmshi Scratch: /osg/tmp OSG_DATA: /osg/data OSG_APP: /osg/app
-CE: ce01.cmsaf.mit.edu:2119/jobmanager-condor-group_cmsprod Scratch: /osg/tmp OSG_DATA: /osg/data OSG_APP: /osg/app
-CE: ce01.cmsaf.mit.edu:2119/jobmanager-condor-group_cmsuser Scratch: /osg/tmp OSG_DATA: /osg/data OSG_APP: /osg/app
-CE: ce01.cmsaf.mit.edu:2119/jobmanager-condor-group_monitor Scratch: /osg/tmp OSG_DATA: /osg/data OSG_APP: /osg/app
-CE: cit-gatekeeper2.ultralight.org:2119/jobmanager-condor-cms_monitor Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
-CE: cit-gatekeeper2.ultralight.org:2119/jobmanager-condor-cms_priority Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
-CE: cit-gatekeeper2.ultralight.org:2119/jobmanager-condor-cms_production Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
-CE: cit-gatekeeper2.ultralight.org:2119/jobmanager-condor-cms_user Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
-CE: cit-gatekeeper.ultralight.org:2119/jobmanager-condor-cms_monitor Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
-CE: cit-gatekeeper.ultralight.org:2119/jobmanager-condor-cms_priority Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
-CE: cit-gatekeeper.ultralight.org:2119/jobmanager-condor-cms_production Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
-CE: cit-gatekeeper.ultralight.org:2119/jobmanager-condor-cms_user Scratch: /wntmp OSG_DATA: /raid2/osg-data OSG_APP: /raid1/osg-app
-CE: cms-0.mps.ohio-state.edu:2119/jobmanager-condor-default Scratch: /hadoop/tmp OSG_DATA: /data/se/osg OSG_APP: /sharesoft/osg/app
-</pre>
-
-%ENDTWISTY%
-
----+ Comments
-%COMMENT{type="tableappend"}%
-
-<!-- CONTENT MANAGEMENT PROJECT
-############################################################################################################
- DEAR DOCUMENT OWNER
- ===================
-
- Thank you for claiming ownership for this document! Please fill in your FirstLast name here:
-   * Local OWNER             = MarcoMambelli
-
- Please define the document area, choose one of the defined areas from the next line
- DOC_AREA = (ComputeElement|Storage|VO|Security|User|Monitoring|General|Trash/Trash/Integration|Operations|Tier3)
-   * Local DOC_AREA       = User
-
- define the primary role the document serves, choose one of the defined roles from the next line
- DOC_ROLE = (EndUser|Student|Developer|SysAdmin|VOManager)
-   * Local DOC_ROLE       = Scientist
-
- Please define the document type, choose one of the defined types from the next line
- DOC_TYPE = (Troubleshooting|Training|Installation|HowTo|Planning|Navigation|Knowledge)
-   * Local DOC_TYPE       = Training
-  Please define if this document in general needs to be reviewed before release ( %YES% | %NO% )
-   * Local INCLUDE_REVIEW = %YES%
-
- Please define if this document in general needs to be tested before release ( %YES% | %NO% )
-   * Local INCLUDE_TEST   = %YES%
-
- change to %YES% once the document is ready to be reviewed and back to %NO% if that is not the case
-   * Local REVIEW_READY   = %YES%
-
- change to %YES% once the document is ready to be tested and back to %NO% if that is not the case
-   * Local TEST_READY     = %YES%
-
- change to %YES% only if the document has passed the review and the test (if applicable) and is ready for release
-   * Local RELEASE_READY  = %YES%
-
-
- DEAR DOCUMENT REVIEWER
- ======================
-
- Thank for reviewing this document! Please fill in your FirstLast name here:
-   * Local REVIEWER       = JamesWeichel 
- Please define the review status for this document to be in progress ( %IN_PROGRESS% ), failed ( %NO% ) or passed ( %YES% )
-   * Local REVIEW_PASSED  = %YES%
-
-
- DEAR DOCUMENT TESTER
- ====================
-
- Thank for testing this document! Please fill in your FirstLast name here:
-   * Local TESTER         = MarcoMambelli 
- Please define the test status for this document to be in progress ( %IN_PROGRESS% ), failed ( %NO% ) or passed ( %YES% )
-   * Local TEST_PASSED    = %YES%
-############################################################################################################
--->

--- a/docs/client/using-wn.md
+++ b/docs/client/using-wn.md
@@ -1,0 +1,55 @@
+
+Introduction
+============
+
+The Worker Node Client is a collection of useful software components that is expected to be on every OSG worker node. In addition, a job running on a worker node can access a handful of environment variables that can be used to locate resources..
+
+This page describes how to initialize the environment of your job to correctly access the execution and data areas from the worker node.
+
+The OSG provides no scientific software dependencies or software build tools on the worker node; you are expected to bring along all application-level dependencies yourself (preferred; most portable) or utilize CVMFS. Sites are not required to provide any specific tools (`gcc`, `lapack`, `blas`, etc.) beyond the ones in the OSG worker node client.
+
+Common software available on worker nodes.
+==========================================
+
+The OSG worker node client (called the `osg-wn-client` package) contains the following software:
+
+-   The supported set of CA certificates (located in $X509_CERT_DIR after the environment is set up)
+-   Proxy management tools:
+    -   Create proxies: `voms-proxy-init` and `grid-proxy-init`
+    -   Show proxy info: `voms-proxy-info` and `grid-proxy-info`
+    -   Destroy the current proxy: `voms-proxy-destroy` and `grid-proxy-destroy`
+-   Data transfer tools:
+    -   HTTP/plain FTP protocol tools (via system dependencies):
+        -   `wget` and `curl`: standard tools for downloading files with HTTP and FTP
+    -   Transfer clients
+        -   `GFAL`-based client (`gfal-copy` and others).  GFAL supports SRM, GridFTP, and HTTP protocols.
+        -   Globus GridFTP client (`globus-url-copy`)
+-   MyProxy client tools
+
+The Worker Node Environment
+===========================
+
+The following table outlines the various important directories and information in the worker node environment. A job running on an OSG worker node can refer to each directory using the corresponding environment variable.
+
+| Environment Variable | Purpose                                            | Notes                                                                                 |
+|:---------------------|:---------------------------------------------------|:--------------------------------------------------------------------------------------|
+| `$X509_CERT_DIR`     | Location of the CA certificates                    |                                                                                       |
+| `$OSG_WN_TMP`        | Temporary storage area in which your job(s) run    | Local to each batch slot. Create a directory under this as your work area.            |
+| `$_CONDOR_SCRATCH_DIR` | Suggested temporary storage are for glideinWMS-based VOs. | Users should prefer this environment variable if running inside glideinWMS.  |
+| `$OSG_SQUID_LOCATION`, `http_proxy` | Location of a HTTP caching proxy server | Utilize this service for downloading files via HTTP for cache-friendly workflows. |
+| `$OSG_GRID`          | Location of additional environment variables.      | Pilots should source `$OSG_GRID/setup.sh` in order to guarantee the environment contains the worker node binaries in `$PATH`. |
+| `$OSG_SITE_NAME`     | Name of the site where the worker node is located. |                                                                                       |
+
+Be careful with using `$OSG_WN_TMP`; at some sites, this directory might be shared with other VOs. We recommend creating a new sub-directory as a precautio:
+
+```shell
+mkdir -p $OSG_WN_TMP/MYVO
+export mydir=`mktemp -d -t MYVO`
+cd $mydir
+# Run the rest of your application
+rm -rf $mydir
+```
+
+A significant number of sites use the batch system to make an independent directory for each user job, and change `$OSG_WN_TMP` on the fly to point to this directory.
+
+There is no way to know in advance how much scratch disk space any given worker node has available; recall, what disk space is available may be shared among a number of job slots.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,8 @@ pages:
   - 'OSG Release Series': 'release/release_series.md'
   - 'RPM Signing': 'release/signing.md'
   - 'Supported Platforms': 'release/supported_platforms.md'
+- Usage Guides:
+  - 'Worker Node Environment': 'client/using-wn.md'
 - In-Progress Docs:
   - 'CA Updater': 'common/ca_updater.md'
   - 'Certificate Request Scripts': 'common/cert_scripts.md'


### PR DESCRIPTION
This document gets significantly shorter once you remove pre-pilot references!
    
Former URL: https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/UsingWorkerNodeClient

- [ ] Enter date into "Migrated" column of google sheet
- [ ] Add migration header to TWiki document

Given no users look at these docs, it's not entirely clear this document has to exist.
