### PR TITLE
Migrate the help procedures document to Markdown.

### DIFF
--- a/docs/archive/HelpProcedure
+++ b/docs/archive/HelpProcedure
@@ -1,0 +1,103 @@
+---+!! *How to Get Help*
+%DOC_STATUS_TABLE%
+%TOC%
+
+---+ About this Document 
+This page is aimed at OSG site administrators looking for support.  Help for users of OSG is found in [[Documentation.UserHelp][User Help]].
+   * If you are looking for documents you'll find an overview of the OSG documentation in the next section.
+   * If you have been sent here from a technical document look at the [[#InformationToHelp][Information Required to Help You section]] and choose your preferred VO or OSG support channel listed below.
+   * For other cases, find the appropriate section below.
+
+#DocHelp
+%INCLUDE{"Documentation.HelpDocuments"}%
+
+---++ Release Specific Notes
+The [[Documentation/Release3.WebHome][Release Web]] contains documents about the current release and is a good starting point for site administrators installing a Compute Element or a Storage Element.
+
+#InformationToHelp
+---++ Information Required to Help You
+
+If you came to this page from an Installation or a !HowTo document in this Twiki, then follow instructions in the *Troubleshooting* and *Debugging* sections of the document and include results in your support inquiry, no matter which channel you choose (email, trouble ticket, web chat, ...) 
+
+For problems with installation of some %LINK_OSG% software run =osg-system-profiler=:
+
+<pre class="screen">
+%UCL_PROMPT_SHORT% osg-system-profiler
+</pre>
+
+And attach =osg-profile.txt= to your support inquiry.
+
+#VoSuport
+%INCLUDE{"Documentation.VOHelpResources" section="VOResourcesList"}%
+
+%INCLUDE{"Documentation.SiteAdminResources"}%
+
+<!--
+%STARTSECTION{"GetHelpInclude"}%
+---+!! %SHIFT% How to Get Help
+We have lots of options for getting help, for more information see [[Documentation/Release3.HelpProcedure][our help page]].
+
+%IF{"$ TOPIC != 'HelpProcedure'" then="" else=" "}%
+%ENDSECTION{"GetHelpInclude"}%
+This section is here only to facilitate inclusion in other documents
+-->
+
+---+ *Comments*
+%COMMENT{type="tableappend"}%
+
+<!-- CONTENT MANAGEMENT PROJECT
+############################################################################################################
+   DEAR DOCUMENT OWNER
+   ===================
+
+   Thank you for claiming ownership for this document! Please fill in your FirstLast name here:
+   * Local OWNER          = MarcoMambelli
+
+   Please define the document area, choose one of the defined areas from the next line
+   DOC_AREA = (ComputeElement|Storage|VO|Security|User|Monitoring|General|Trash/Trash/Integration|Operations|Tier3)
+   * Local DOC_AREA       = General
+
+   define the primary role the document serves, choose one of the defined roles from the next line
+   DOC_ROLE = (EndUser|Student|Developer|SysAdmin|VOManager|Documenter)
+   * Local DOC_ROLE       = SysAdmin
+
+   Please define the document type, choose one of the defined types from the next line
+   DOC_TYPE = (Troubleshooting|Training|Installation|HowTo|Planning|Navigation|Knowledge)
+   * Local DOC_TYPE       = Troubleshooting
+   
+   Please define if this document in general needs to be reviewed before release ( %YES% | %NO% )
+   * Local INCLUDE_REVIEW = %YES%
+
+   Please define if this document in general needs to be tested before release ( %YES% | %NO% )
+   * Local INCLUDE_TEST   = %NO%
+
+   change to %YES% once the document is ready to be reviewed and back to %NO% if that is not the case
+   * Local REVIEW_READY   = %YES%
+
+   change to %YES% once the document is ready to be tested and back to %NO% if that is not the case
+   * Local TEST_READY     = %NO%
+
+   change to %YES% only if the document has passed the review and the test (if applicable) and is ready for release
+   * Local RELEASE_READY  = %YES%
+
+
+   DEAR DOCUMENT REVIEWER
+   ======================
+
+   Thank for reviewing this document! Please fill in your FirstLast name here:
+   * Local REVIEWER       = JamesWeichel
+  
+   Please define the review status for this document to be in progress ( %IN_PROGRESS% ), failed ( %NO% ) or passed ( %YES% )
+   * Local REVIEW_PASSED  = %YES%
+
+
+   DEAR DOCUMENT TESTER
+   ====================
+
+   Thank for testing this document! Please fill in your FirstLast name here:
+   * Local TESTER         = 
+  
+   Please define the test status for this document to be in progress ( %IN_PROGRESS% ), failed ( %NO% ) or passed ( %YES% )
+   * Local TEST_PASSED    = %IN_PROGRESS%
+############################################################################################################
+-->

--- a/docs/common/help.md
+++ b/docs/common/help.md
@@ -1,0 +1,45 @@
+How to Get Help
+===============
+
+This page is aimed at OSG site administrators looking for support. Help for OSG users is found at [our support desk](https://support.opensciencegrid.org/support/home).
+
+Grid Operations Center
+----------------------
+
+The Grid Operations Center (GOC) is available to coordinate users, site admins, and developers around an issue.  Additionally, the GOC can provide basic monitoring and troubleshooting.  There are several ways to receive support:
+
+*  You can [submit a trouble ticket](https://ticket.grid.iu.edu) or send an email to [goc@opensciencegrid.org](mailto:goc@opensciencegrid.org) (which also accept general inquiries not intended for tickets.)
+*  The [trouble ticket system](https://ticket.grid.iu.edu/goc/list/open) is searchable.  Historical tickets may contain the solution for similar problems others have encountered.
+*  The [operations blog](http://osggoc.blogspot.com/) contains information about recent software releases, and important outage and maintenance notifications of central OSG services.
+*  For emergencies, the OSG Grid Operation Center provides extended support. Operators are on hand 24x7 at the GOC and can be reached via phone at +1 317-278-9699.   Non-emergency issues can be opened 24x7 but will be handled during normal business hours.
+
+
+Security incident
+-----------------
+
+Security incidents can be reported by following the instructions on the [Incident Discovery and Reporting](https://opensciencegrid.github.io/security/IncidentDiscoveryReporting/) page.  Additional steps to aid in the incident handling process are also linked from that page.
+
+Information Required to Help You
+--------------------------------
+
+If you came to this page from an installation or other document in this website, then follow instructions in the **Troubleshooting** and **Debugging** sections of the document and include results in your support inquiry, no matter which channel you choose (email, trouble ticket, web chat, ...)
+
+For problems with installation of some software run `osg-system-profiler`:
+
+```console
+[root@client ~] # osg-system-profiler
+```
+
+Attach the generated `osg-profile.txt` to your support inquiry.
+
+Community-specific Resources
+----------------------------
+
+Some OSG VOs have dedicated forums or mechanisms for community-specific support.  If your VO provides user support, that should be a user's first line of support because the VO is most familiar with your applications and requirements.
+
+*  The list of support contacts for OSG VOs can be found in the [Support Center Tab on MyOSG](http://myosg.grid.iu.edu/scsummary/index?datasource=summary&summary_attrs_showdesc=on&summary_attrs_showcontact=on&all_scs=on&active=on&active_value=1).
+* Resources for **CMS** sites:
+    * <http://www.uscms.org/uscms_at_work/physics/computing/grid/index.shtml>
+    * CMS Hyper News: <https://hypernews.cern.ch/HyperNews/CMS/get/osg-tier3.html>
+    * CMS Twiki: <https://twiki.cern.ch/twiki/bin/viewauth/CMS/USTier3Computing>
+

--- a/docs/common/help.md
+++ b/docs/common/help.md
@@ -22,7 +22,7 @@ Security incidents can be reported by following the instructions on the [Inciden
 Information Required to Help You
 --------------------------------
 
-If you came to this page from an installation or other document in this website, then follow instructions in the **Troubleshooting** and **Debugging** sections of the document and include results in your support inquiry, no matter which channel you choose (email, trouble ticket, web chat, ...)
+If you came to this page from an installation or other document in this website, then follow instructions in the **Troubleshooting** and **Debugging** sections of that document and include results in your support inquiry, no matter which channel you choose (email, trouble ticket, web chat, ...)
 
 For problems with installation of some software run `osg-system-profiler`:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ pages:
   - 'BeStMan Overview': 'storage/bestman-overview.md'
   - 'BeStMan Install': 'storage/bestman-install.md'
   - 'Worker node glexec': 'client/glexec.md'
+- 'Get Help': 'common/help.md'
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
Original URL: https://twiki.opensciencegrid.org/bin/view/Documentation/SiteAdminResources

This page was significantly cleaned up, removing long-defunct help mechanisms.

- [ ] Enter date into "Migrated" column of google sheet
- [ ] Add migration header to TWiki document