### PR TITLE
Fix internal links in docs

### DIFF
--- a/archive/InstallCertAuth
+++ b/archive/InstallCertAuth
@@ -1,0 +1,411 @@
+%DOC_STATUS_TABLE%
+
+---+!! Installing Certificate Authorities Certificates and related RPMs
+%TOC%
+
+---+About this Document
+This document provides you with details of various options to install the Certificate Authority (CA) certificates and have up-to-date certificate revocation list (CRL).
+
+---+ How to get Help?
+To get assistance please use [[HelpProcedure][Help Procedure]].
+
+---+ Background
+
+When installing software with RPMs, you need to decide how you want to install the Certificate Authority (CA) certificates. You might ask "why do I care? Can't you just give them to me?" We can, but you have a few things to consider:
+
+   * What set of CA certificates do you want? How much control do you want over the set of CA certificates? (Some sites might not want to install specific CAs for policy or security reasons.)
+   * How do you want to update them?
+   * Do you want to centrally manage the CA certificates or install them on each computer at your site?
+
+You have four options for installing CA certificates:
+
+   1. Install an RPM for a specific set of CA certificates.
+   1. Install =osg-update-certs=, a program that lets you install/update a predefined set of CA certificates, then adjust the set by adding or deleting specific CAs.
+   1. Install an RPM that installs *no* CAs. This is useful when you want your RPM installations to succeed (because our RPMs require CA certificates, and this RPM satisfies that dependency) but you want to manage them with your own technique.
+   1. Make no choice, let =yum= decide for you.
+
+Additionally this page also provides instruction on installation of a tool (fetch-crl) to ensure your site has up-to-date certificate revocation list (CRL) from the CA.
+
+---+ First: Set up the yum repositories
+
+%INCLUDE{"YumRepositories" section="OSGRepoBrief"}%
+
+---+ Install CA certificates: Options
+Please choose one of the four options to install the CA certificates.
+
+---++ Option 1: Install an RPM for a specific set of CA certificates
+
+If you want to install an RPM for one of our predefined CA certificates, you have two choices to make:
+
+*Choice: Which set of CAs?*
+   a. (_recommended_) The OSG CA certificates. This is similar to the IGTF set, but may have a small number of additions or deletions. (See [[InstallCertAuth#Contents_of_OSG_CA_package][here]] for details)
+   a. The default [[http://www.igtf.net/][IGTF]] CA certificates.
+
+Depending on your choice, you select one of two RPMs:
+
+%TABLE{ sort="off" valign="top" }%
+| *Set of CAs* | *Format* | *RPM name* | *Installation command (as root)* |
+| OSG | !OpenSSL-both | osg-ca-certs | =yum install osg-ca-certs= |
+| IGTF | !OpenSSL-both | igtf-ca-certs | =yum install igtf-ca-certs= |
+
+*How do I keep CAs updated?*
+
+Please follow the instruction under OsgCaCertsUpdater make sure that the CAs are kept updated.
+
+---++ Option 2: Install osg-update-certs
+
+(In the Pacman world, this was vdt-update-certs).
+
+Install this with: <pre class=screen>%UCL_PROMPT_ROOT% yum install osg-ca-scripts</pre>
+
+You have the same choices for CA certificates as above. In order to choose, you will run osg-ca-manage, which will install the CA certificates. Then (if desired) you need to enable periodic updating of the CA certificates.
+
+%TABLE{ sort="off" valign="top" }%
+| *Set of CAs* | *Format* | *CA certs name* | * Installation command (as root)* |
+| OSG | !OpenSSL-both | osg | =/usr/sbin/osg-ca-manage setupCA --location root --url osg= |
+| IGTF | !OpenSSL-both | igtf | =/usr/sbin/osg-ca-manage setupCA --location root --url igtf= |
+
+Here is an example:
+
+<pre class="screen">
+%UCL_PROMPT_ROOT% /usr/sbin/osg-ca-manage setupCA --location root --url osg
+Setting up CA Certificates for OSG installation
+CA Certificates will be installed into /etc/grid-security/certificates
+osg-update-certs
+  Log file: /var/log/osg-update-certs.log
+  Updates from: http://software.grid.iu.edu/pacman/cadist/ca-certs-version-new
+
+Will update CA certificates from version unknown to version 1.21NEW.
+Update successful.
+
+Setup completed successfully.
+</pre>
+
+Initially the CA certificates will not be updated. You can tell by looking at:
+
+<pre class="screen">%UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  status
+Periodic osg-update-certs is disabled.</pre>
+
+You can enable the =cron= job that updates the CA certs with:
+<pre class="screen">%UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  start
+Enabling periodic osg-update-certs:                        [  %GREEN%OK%ENDCOLOR%  ]</pre>
+
+A complete set of options available though =osg-ca-manage= command, including your interface to adding and removing CAs, could be found at [[OsgCaManage][osg-ca-manage documentation]]
+
+---++ Option 3:  Install an RPM that installs no CAs
+Install this with: <pre class=screen>yum install empty-ca-certs --enablerepo=osg-empty</pre>
+
+%RED%*Warning:*%ENDCOLOR% If you choose this option, you are responsible for installing the CA certificates yourself. You must install them in =/etc/grid-security/certificates=, or make a symlink from that location to the directory that contains the CA certificates.
+
+---++ Option 4: Make no choice, let yum decide for you
+If you use =yum= to install software that requires CA certificates but you haven't made one of these choices, yum will choose a default. Right now, it is Option #1 from above (_Install an RPM for a specific set of CA certificates_), and the osg-ca-certs RPM is chosen.
+
+---++ Install other CAs
+
+In addition to the above CAs, you can install other CAs via RPM. These only work with the RPMs that provide CAs (that is, =osg-ca-certs= and the like, but not =osg-ca-scripts=.) They are in addition to the above RPMs, so do not only install these extra CAs.
+
+%TABLE{ sort="off" valign="top" }%
+| *Set of CAs* | *Format* | *RPM name* | *Installation command (as root)* |
+| cilogon-basic & cilogon-openid | !OpenSSL-both | cilogon-ca-certs | =yum install cilogon-ca-certs= |
+
+---+ Managing Certificate Revocation Lists
+
+In addition to CA certificates, you normally need to have updated Certificate Revocation Lists (CRLs) which are are lists of certificates that have been revoked for any reason. Software in the OSG Software Stack use these to ensure that you are talking to valid clients or servers. We use a tool named =fetch-crl= that periodically updates the CRLs.  Fetch CRL is a utility that updates Certificate Authority (CA) Certificate Revocation Lists (CRLs). These are lists of certificates that were granted by the CA, but have since been revoked. It is good practice to regularly update the CRL list for each CA to ensure that you do not authenticate any certificate that has been revoked.
+
+Unlike the older Pacman-based version, fetch-crl is now installed as two different system services. The  fetch-crl-boot service runs only at boot time.  The fetch-crl-cron "service" runs fetch-crl every 6 hours (with a random sleep time included) by default.  Both services are disabled by default.  At the very minimum, the fetch-crl-cron "service" needs to be enabled otherwise services will begin to fail as the existing CRLs expire.
+In RHEL5 (!CentOS 5, SL5) systems there has been a disruptive update in OSG 3.1.15 that changed the name from fetch-crl to fetch-crl3. If you are affected by the update or want to read more please [[UpgradeFetchCrl2to3][check here]].
+
+---++ Install =fetch-crl=
+%STARTSECTION{"FetchCRLInstall"}%
+Normally fetch-crl is installed when you install the rest of the software and you do not need to specifically install it. If you do wish to install it, you can install it as:
+%STARTSECTION{"FetchCRLInstallShort"}% <pre class="rootscreen">
+%RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
+%UCL_PROMPT_ROOT% yum install fetch-crl3
+%RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7, or OSG 3 _older_ than 3.1.15%ENDCOLOR%
+%UCL_PROMPT_ROOT% yum install fetch-crl
+</pre> %ENDSECTION{"FetchCRLInstallShort"}%
+
+%NOTE% The fetch-crl scripts for RHEL 5 (CentOS 5, and SL5) have changed name in OSG 3.1.15. Both the package and the scripts are called =fetch-crl3...= instead of =fetch-crl...=
+%ENDSECTION{"FetchCRLInstall"}%
+
+
+%STARTSECTION{"FetchCRLConfig"}%
+---%SHIFT%++ Enable and Start =fetch-crl=
+To enable fetch-crl (fetch Certificate Revocation Lists) services by default on the node:
+<pre class="rootscreen">
+%RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
+%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-boot on
+%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-cron on
+%RED%# For RHEL 6, CentOS 6, and SL6, or OSG 3 _older_ than 3.1.15 %ENDCOLOR%
+%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-boot on
+%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-cron on
+%RED%# For RHEL 7, CentOS 7, and SL7 %ENDCOLOR%
+%UCL_PROMPT_ROOT% systemctl enable fetch-crl-boot
+%UCL_PROMPT_ROOT% systemctl enable fetch-crl-cron
+</pre>
+To start fetch-crl:
+<pre class="rootscreen">
+%RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
+%UCL_PROMPT_ROOT% /sbin/service fetch-crl3-boot start
+%UCL_PROMPT_ROOT% /sbin/service fetch-crl3-cron start
+%RED%# For RHEL 6, CentOS 6, and SL6, or OSG 3 _older_ than 3.1.15 %ENDCOLOR%
+%UCL_PROMPT_ROOT% /sbin/service fetch-crl-boot start
+%UCL_PROMPT_ROOT% /sbin/service fetch-crl-cron start
+%RED%# For RHEL 7, CentOS 7, and SL7 %ENDCOLOR%
+%UCL_PROMPT_ROOT% systemctl start fetch-crl-boot
+%UCL_PROMPT_ROOT% systemctl start fetch-crl-cron
+</pre>
+*NOTE*: while it is necessary to start =fetch-crl-cron= in order to have it active, =fetch-crl-boot= is started automatically at boot time if enabled. The start command will run =fetch-crl-boot= at the moment when it is invoked and it may take some time to complete.
+
+---%SHIFT%++ Configure =fetch-crl=
+To modify the times that fetch-crl-cron runs, edit =/etc/cron.d/fetch-crl= (or =/etc/cron.d/fetch-crl3= depending on the version you have).
+
+%STARTSECTION{"FetchCRLConfigProxy"}%
+By default, =fetch-crl= connects directly to the remote CA; this is inefficient and potentially harmful if done simultaneously by many nodes (e.g. all the worker nodes of a big cluster).  We recommend you provide a HTTP proxy (such as squid) the worker nodes can connect to. [[InstallFrontierSquid][Here]] are instructions to install a squid proxy.
+
+To configure fetch-crl to use an HTTP proxy server:
+   * If using =fetch-crl= version 2 (the =fetch-crl= package on RHEL5 only), then create the file  =/etc/sysconfig/fetch-crl= and add the following line: <pre class="file">
+export http_proxy=%RED%http://your.squid.fqdn:port%ENDCOLOR%
+</pre> Adjust the URL appropriately for your proxy server.
+   * If using =fetch-crl= version 3 on RHEL5 via the =fetch-crl3= package or on RHEL6/RHEL7 via the =fetch-crl= package, then create or edit the file =/etc/fetch-crl3.conf= (RHEL5) or =/etc/fetch-crl.conf= (RHEL6/RHEL7) and add the following line: <pre class="file">
+http_proxy=%RED%http://your.squid.fqdn:port%ENDCOLOR%
+</pre> Again, adjust the URL appropriately for your proxy server.
+
+Note that the ==nosymlinks== option in the configuration files refers to ignoring links within the certificates directory (e.g. two different names for the same file). It is perfectly fine if the path of the CA certificates directory itself (=infodir=) is a link to a directory.
+
+Any modifications to the configuration file will be preserved during an RPM update.
+
+%IF{"$ TOPIC != 'InstallCertAuth'" then="For more details, please see our [[Documentation.Release3.InstallCertAuth][fetch-crl documentation]]." else=""}%
+%ENDSECTION{"FetchCRLConfigProxy"}%
+
+Current versions of fetch-crl and fetch-crl3 produce more output. It is possible to send the output to syslog instead of the default email system. To do so:
+   1. Change the configuration file to enable syslog: <pre class="file">
+logmode = syslog
+syslogfacility = daemon</pre>
+   1. Make sure the file =/var/log/daemon= exists, e.g. touching the file
+   1. Change =/etc/logrotate.d= files to rotate it
+
+%ENDSECTION{"FetchCRLConfig"}%
+
+%STARTSECTION{"OSGBriefCaCerts"}%
+---%SHIFT%+ Install the CA Certificates: A quick guide
+
+You must perform one of the following =yum= commands below to select this host's CA certificates.
+
+| *Set of CAs* |  *CA certs name* | * Installation command (as root)* |
+| OSG | osg-ca-certs | =yum install osg-ca-certs= %RED%<b>Recommended</b>%ENDCOLOR% |
+| IGTF | igtf-ca-certs | =yum install igtf-ca-certs= |
+| None* | empty-ca-certs | =yum install empty-ca-certs --enablerepo=osg-empty= |
+| Any** | Any | =yum install osg-ca-scripts= |
+
+* The =empty-ca-certs= RPM indicates you will be manually installing the CA certificates on the node. <br/>
+** The =osg-ca-scripts= RPM provides a cron script that automatically downloads CA updates, and requires further configuration. <br/>
+
+%NOTE% If you use options 1 or 2, then you will need to run "yum update" in order to get the latest version of CAs when they are released. With option 4 a cron service is provided which will always download the updated CA package for you.
+%NOTE% If you use services like Apache's httpd you must restart them after each update of the CA certificates, otherwise they will continue to use the old version of the CA certificates.
+%IF{"$ TOPIC != 'InstallCertAuth'" then="For more details and options, please see our [[Documentation.Release3.InstallCertAuth][CA certificates documentation]]." else=""}%
+%ENDSECTION{"OSGBriefCaCerts"}%
+
+
+%STARTSECTION{"OSGBriefFetchCrlStartStop"}%
+---%SHIFT%+ Start/Stop fetch-crl: A quick guide
+
+%STARTSECTION{"OSGBriefFetchCrlStart"}% You need to fetch the latest CA Certificate Revocation Lists (CRLs) and you should enable the fetch-crl service to keep the CRLs up to date:<pre class="rootscreen">
+%RED%# For RHEL 6, CentOS 6, and SL6, or OSG 3 _older_ than 3.1.15 %ENDCOLOR%
+%UCL_PROMPT_ROOT% /usr/sbin/fetch-crl   # This fetches the CRLs
+%UCL_PROMPT_ROOT% /sbin/service fetch-crl-boot start
+%UCL_PROMPT_ROOT% /sbin/service fetch-crl-cron start
+%RED%# For RHEL 7, CentOS 7, and SL7 %ENDCOLOR%
+%UCL_PROMPT_ROOT% /usr/sbin/fetch-crl   # This fetches the CRLs
+%UCL_PROMPT_ROOT% systemctl start fetch-crl-boot
+%UCL_PROMPT_ROOT% systemctl start fetch-crl-cron
+</pre> %IF{"$ TOPIC != 'InstallCertAuth'" then="For more details and options, please see our [[Documentation.Release3.InstallCertAuth#Managing_Certificate_Revocation][CRL documentation]]." else=""}%  %ENDSECTION{"OSGBriefFetchCrlStart"}%
+
+%STARTSECTION{"OSGBriefFetchCrlEnable"}% To enable the fetch-crl service to keep the CRLs up to date after reboots:<pre class="rootscreen">
+%RED%# For RHEL 6, CentOS 6, and SL6, or OSG 3 _older_ than 3.1.15 %ENDCOLOR%
+%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-boot on
+%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-cron on
+%RED%# For RHEL 7, CentOS 7, and SL7 %ENDCOLOR%
+%UCL_PROMPT_ROOT% systemctl enable fetch-crl-boot
+%UCL_PROMPT_ROOT% systemctl enable fetch-crl-cron
+</pre> %ENDSECTION{"OSGBriefFetchCrlEnable"}%
+
+
+%STARTSECTION{"OSGBriefFetchCrlStop"}% To stop fetch-crl:<pre class="rootscreen">
+%RED%# For RHEL 6, CentOS 6, and SL6, or OSG 3 _older_ than 3.1.15 %ENDCOLOR%
+%UCL_PROMPT_ROOT% /sbin/service fetch-crl-boot stop
+%UCL_PROMPT_ROOT% /sbin/service fetch-crl-cron stop
+%RED%# For RHEL 7, CentOS 7, and SL7 %ENDCOLOR%
+%UCL_PROMPT_ROOT% systemctl stop fetch-crl-boot
+%UCL_PROMPT_ROOT% systemctl stop fetch-crl-cron
+</pre> %IF{"$ TOPIC != 'InstallCertAuth'" then="For more details and options, please see our [[Documentation.Release3.InstallCertAuth#Managing_Certificate_Revocation][CRL documentation]]." else=""}%  %ENDSECTION{"OSGBriefFetchCrlStop"}% %ENDSECTION{"OSGBriefFetchCrlStartStop"}%
+
+%STARTSECTION{"OSGBriefFetchCrlDisable"}% To disable the fetch-crl service:<pre class="rootscreen">
+%RED%# For RHEL 6, CentOS 6, and SL6, or OSG 3 _older_ than 3.1.15 %ENDCOLOR%
+%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-boot off
+%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-cron off
+%RED%# For RHEL 7, CentOS 7, and SL7 %ENDCOLOR%
+%UCL_PROMPT_ROOT% systemctl disable fetch-crl-boot
+%UCL_PROMPT_ROOT% systemctl disable fetch-crl-cron
+</pre> %ENDSECTION{"OSGBriefFetchCrlDisable"}%
+
+
+
+---+ Updating CAs/CRLs
+---++ Why maintain up-to-date Trusted CA /CRL information
+The Trusted Certificate Authority (CA) certificates, and their associated Certificate Revocation Lists (CRLs), are used for every transaction on a resource that establishes an authenticated network connection based on end user's certificate. In order for the authentication to succeed, the user's certificate must have been issued by one of the CAs in the Trusted CA directory, and the user's certificate must not be listed in the CRL for that CA. CRLs can be thought of as a black list of certificates. CAs are the trust authorities, similar to DMV that issues you the driving license.  (Another way of thinking CRLs is the do-not-fly lists at the airports. if your certificate shows up in CRLs, you are not allowed access.) This is handled at the certificate validation stage even before the authorization check (which will provide the mapping of an authenticated user to a local account UID/GID). So you do not need to do worry about it; the grid software will do this for you. However, you should make sure that your site has the most up-to-date list of Trusted CAs. There are multiple trust authorities in OSG (think of it as a different DMV for each state). If you do not have an up-to-date list of CAs it is possible that some of your users transactions at your site will start to fail.  A current CRL list for each CA is also necessary, since without one transactions for users of that CA will fail.
+
+%STARTSECTION{"OSGBriefCaCrlUpdates"}%
+---++ How to ensure you are get up-to-date CA/CRL information
+   1. <p>If you installed CAs using rpm packages (osg-ca-certs,igtf-ca-certs) (Options 1, 4),  you will need to install the software described in OsgCaCertsUpdater, and enable osg-ca-certs-updater service to keep the CAs automatically updated. If you do not install OsgCaCertsUpdater you will have to regularly run yum update to keep the CAs updated.</p>
+   1. If you use Option 2 (i.e. osg-update-certs) then make sure that you have cron enabled\
+<pre class="screen">%UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  status
+Periodic osg-update-certs is enabled.</pre>
+   1. Ensure that fetch-crl cron is enabled\
+<pre class="screen">%UCL_PROMPT_ROOT% /sbin/service fetch-crl-cron  status
+Periodic fetch-crl is enabled.</pre>
+%ENDSECTION{"OSGBriefCaCrlUpdates"}%
+
+---+ Troubleshooting
+---++  Useful configuration and log files
+
+Configuration files:
+| *Package* | *File Description* | *Location* | *Comment* |
+| All CA Packages | CA File Location | =/etc/grid-security/certificates= | |
+| All CA Packages | Index files | =/etc/grid-security/certificates/INDEX.html= or =/etc/grid-security/certificates/INDEX.txt= | Latest version also available at http://software.grid.iu.edu/pacman/cadist/ |
+| All CA Packages | Change Log | =/etc/grid-security/certificates/CHANGES= | Latest version also available at http://software.grid.iu.edu/pacman/cadist/CHANGES |
+| osg-ca-certs or igtf-ca-certs | contain only CA files |  | |
+| osg-ca-scripts | Configuration File for osg-update-certs | =/etc/osg/osg-update-certs.conf= | This file may be edited by hand, though it is recommended to use osg-ca-manage to set configuration parameters. |
+| fetch-crl-2.x | Configuration file | =/etc/fetch-crl.conf= | |
+| fetch-crl-3.x | Configuration file | =/etc/fetch-crl3.conf= | |
+The index and change log files contain a summary of all the CA distributed and their version.
+
+Logs files:
+| *Package* | *File Description* | *Location* | *Comment* |
+| osg-ca-scripts | Log file of osg-update-certs | =/var/log/osg-update-certs.log= |  |
+| osg-ca-scripts | Stdout of osg-update-certs | =/var/log/osg-ca-certs-status.system.out= |  |
+| osg-ca-scripts | Stdout of osg-ca-manage | =/var/log/osg-ca-manage.system.out= |  |
+| osg-ca-scripts | Stdout of initial CA setup | =/var/log/osg-setup-ca-certificates.system.out= |  |
+
+---++ Tests
+---+++ Test the host certificates
+To test the host certificate of a server =openssl s_client= can be used. Here is an example with the gatekeeper:
+<pre class=screen>%UCL_PROMPT% openssl s_client -showcerts -cert /etc/grid-security/hostcert.pem -key /etc/grid-security/hostkey.pem -CApath /etc/grid-security/certificates/ -debug -connect osg-gk.mwt2.org:2119</pre>
+
+---++ Frequently Asked Questions
+---+++ Location of Certificates?
+<pre class="file"> /etc/grid-security/certificates </pre>
+
+---+++ What is the version of OSG CA package I have installed and what are its contents?
+The version of the CA package ca  be found at =/etc/grid-security/certificates/INDEX.html= or =/etc/grid-security/certificates/INDEX.txt=. The changes file can be found at =/etc/grid-security/certificates/CHANGES=.
+
+---+++ Contents of OSG CA package?
+
+The OSG CA Distribution contains:
+   * [[http://dist.eugridpma.info/distribution/igtf/current/][IGTF Distribution of Authority Root Certificates]] (CAs accredited by the [[http://igtf.net/][International Grid Trust Federation]])
+   * [[http://tg-ca.purdue.teragrid.org:8080/ejbca/][Purdue TeraGrid CA]]
+
+Details of CAs in OSG distribution can be found [[Documentation.CaDistribution#Contents][here]]. For additional details what is in the current release, see the [[http://software.grid.iu.edu/pacman/cadist/][distribution site]] and [[http://software.grid.iu.edu/pacman/cadist/CHANGES][change log]].
+
+---+++ How can I add or remove a particular CA file?
+Add and remove of CA files are supported only if you CA files are being installed using osg-update-certs, which is included in the osg-ca-scripts package (option 2), for all other options no support for adding and removing a particular CA  file is provided by OSG. The preferred approach to add or remove a CA is to use  [[OsgCaManage][osg-ca-manage]]. For adding a new CA =osg-ca-manage add [--dir <local_dir>] --hash <CA_hash>= may be used, while a CA is removed using =osg-ca-manage remove --hash <CA_hash>=.
+
+---+++ Are there any log files or configuration files associated with CA certificate package?
+If CA files are installed using =osg-ca-certs= or =igtf-ca-certs= rpms (i.e. options 1, 4) no log or configuration files are present.
+
+Log and configuration files are however present for =osg-ca-scripts= rpm package (option 2).
+
+Config files:  =/etc/osg/osg-update-certs.conf=
+Log files: =/var/log/osg-update-certs.log=, =/var/log/osg-ca-certs-status.system.out=, =/var/log/osg-ca-manage.system.out=, =/var/log/osg-setup-ca-certificates.system.out=
+
+---+++ Are CA packages automatically updated?
+If CA files are installed using =osg-ca-certs= or =igtf-ca-certs= rpms (i.e. options 1, 4), you will  need to install the software described in OsgCaCertsUpdater, and enable osg-ca-certs-updater service to keep the CAs automatically updated.
+
+If CA files are being installed using  =osg-ca-scripts= rpm package (option 2), CA files are kept up-to-date as long as =osg-update-certs-cron= service the package provides has been started.
+
+---+++ How do I manually update my CA package?
+For Option 1: run one of the following =yum update osg-ca-certs= or =yum update igtf-ca-certs= depending on the rpm package you installed.
+
+For Option 4: run =yum update osg-ca-certs=
+
+For Option 2: You do not need to do a manual update, make sure =osg-update-certs-cron= is enabled using
+<pre class="screen">%UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  status</pre>
+If the service is disabled, enable it using
+<pre class="screen">%UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  start</pre>
+If for some extraordinary reason you need to manually update the CA you could run =osg-ca-manage [--force] refreshCA=.
+
+---+++ Where are the configuration files for fetch-crl?
+
+=/etc/fetch-crl.conf= or =/etc/fetch-crl3.conf= for fetch-crl 2.x or 3.x respectively
+
+---+ References
+Some guides on x509 certificates:
+   * Useful commands: http://security.ncsa.illinois.edu/research/grid-howtos/usefulopenssl.html
+   * Install GSI authentication on a server: http://security.ncsa.illinois.edu/research/wssec/gsihttps/
+   * Certificates how-to: http://www.nordugrid.org/documents/certificate_howto.html
+Some examples about verifying the certificates:
+   * http://gagravarr.org/writing/openssl-certs/others.shtml
+   * http://www.cyberciti.biz/faq/test-ssl-certificates-diagnosis-ssl-certificate/
+   * http://www.cyberciti.biz/tips/debugging-ssl-communications-from-unix-shell-prompt.html
+Related software:
+   * Description, manual and examples of OsgCaManage
+   * OsgCaCertsUpdater
+   * [[UpgradeFetchCrl2to3][Upgrading Fetch-Crl 2 to Fetch-Crl 3 on EL5]]
+
+---+ Comments
+%COMMENT{type="tableappend"}%
+
+<!-- CONTENT MANAGEMENT PROJECT
+############################################################################################################
+ DEAR DOCUMENT OWNER
+ ===================
+
+ Thank you for claiming ownership for this document! Please fill in your FirstLast name here:
+   * Local OWNER = AnandPadmanabhan
+
+ Please define the document area, choose one of the defined areas from the next line
+ DOC_AREA = (ComputeElement|Storage|VO|Security|User|Monitoring|General|Trash/Trash/Integration|Operations|Tier3)
+   * Local DOC_AREA       = Security
+
+ define the primary role the document serves, choose one of the defined roles from the next line
+ DOC_ROLE = (EndUser|Student|Developer|SysAdmin|VOManager)
+   * Local DOC_ROLE       = SysAdmin
+
+ Please define the document type, choose one of the defined types from the next line
+ DOC_TYPE = (Troubleshooting|Training|Installation|HowTo|Planning|Navigation|Knowledge)
+   * Local DOC_TYPE       = Installation
+  Please define if this document in general needs to be reviewed before release ( %YES% | %NO% )
+   * Local INCLUDE_REVIEW = %YES%
+
+ Please define if this document in general needs to be tested before release ( %YES% | %NO% )
+   * Local INCLUDE_TEST   = %YES%
+
+ change to %YES% once the document is ready to be reviewed and back to %NO% if that is not the case
+   * Local REVIEW_READY   = %YES%
+
+ change to %YES% once the document is ready to be reviewed and back to %NO% if that is not the case
+   * Local TEST_READY   = %YES%
+
+ change to %YES% only if the document has passed the review and the test (if applicable) and is ready for release
+   * Local RELEASE_READY  = %YES%
+
+
+ DEAR DOCUMENT REVIEWER
+ ======================
+
+ Thank for reviewing this document! Please fill in your FirstLast name here:
+   * Local REVIEWER       = MarcoMambelli
+ Please define the review status for this document to be in progress ( %IN_PROGRESS% ), failed ( %NO% ) or passed ( %YES% )
+   * Local REVIEW_PASSED  = %YES%
+
+
+DEAR DOCUMENT TESTER
+ ====================
+
+ Thank for testing this document! Please fill in your FirstLast name here:
+   * Local TESTER         = MarcoMambelli
+ Please define the test status for this document to be in progress ( %IN_PROGRESS% ), failed ( %NO% ) or passed ( %YES% )
+   * Local TEST_PASSED    = %YES%
+
+############################################################################################################
+-->

--- a/docs/common/ca.md
+++ b/docs/common/ca.md
@@ -33,7 +33,7 @@ If you want to install an RPM for one of our predefined CA certificates, you hav
 
 ### Which set of CAs?
 
-1.  (*recommended*) The OSG CA certificates. This is similar to the IGTF set, but may have a small number of additions or deletions. (See [here](InstallCertAuth#Contents_of_OSG_CA_package) for details)
+1.  (*recommended*) The OSG CA certificates. This is similar to the IGTF set, but may have a small number of additions or deletions. (See [here](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallCertAuth#Contents_of_OSG_CA_package) for details)
 2.  The default [IGTF](http://www.igtf.net/) CA certificates.
 
 Depending on your choice, you select one of two RPMs:
@@ -93,7 +93,7 @@ You can enable the `cron` job that updates the CA certs with:
 Enabling periodic osg-update-certs:                        [  %GREEN%OK%ENDCOLOR%  ]
 ```
 
-A complete set of options available though `osg-ca-manage` command, including your interface to adding and removing CAs, could be found at [osg-ca-manage documentation](OsgCaManage)
+A complete set of options available though `osg-ca-manage` command, including your interface to adding and removing CAs, could be found at [osg-ca-manage documentation](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/OsgCaManage)
 
 Option 3: Install an RPM that installs no CAs
 ---------------------------------------------
@@ -308,8 +308,8 @@ Configuration files:
 | Package                       | File Description                        | Location                                                                                    | Comment                                                                                                         |
 |:------------------------------|:----------------------------------------|:--------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------|
 | All CA Packages               | CA File Location                        | `/etc/grid-security/certificates`                                                           |                                                                                                                 |
-| All CA Packages               | Index files                             | `/etc/grid-security/certificates/INDEX.html` or `/etc/grid-security/certificates/INDEX.txt` | Latest version also available at <http://software.grid.iu.edu/pacman/cadist/>                                   |
-| All CA Packages               | Change Log                              | `/etc/grid-security/certificates/CHANGES`                                                   | Latest version also available at <http://software.grid.iu.edu/pacman/cadist/CHANGES>                            |
+| All CA Packages               | Index files                             | `/etc/grid-security/certificates/INDEX.html` or `/etc/grid-security/certificates/INDEX.txt` | Latest version also available at <http://repo.grid.iu.edu/pacman/cadist/>                                   |
+| All CA Packages               | Change Log                              | `/etc/grid-security/certificates/CHANGES`                                                   | Latest version also available at <http://repo.grid.iu.edu/pacman/cadist/CHANGES>                            |
 | osg-ca-certs or igtf-ca-certs | contain only CA files                   |                                                                                             |                                                                                                                 |
 | osg-ca-scripts                | Configuration File for osg-update-certs | `/etc/osg/osg-update-certs.conf`                                                            | This file may be edited by hand, though it is recommended to use osg-ca-manage to set configuration parameters. |
 | fetch-crl-2.x                 | Configuration file                      | `/etc/fetch-crl.conf`                                                                       |                                                                                                                 |
@@ -355,11 +355,11 @@ The OSG CA Distribution contains:
 -   [IGTF Distribution of Authority Root Certificates](http://dist.eugridpma.info/distribution/igtf/current/) (CAs accredited by the [International Grid Trust Federation](http://igtf.net/))
 -   [Purdue TeraGrid CA](http://tg-ca.purdue.teragrid.org:8080/ejbca/)
 
-Details of CAs in OSG distribution can be found [here](Documentation.CaDistribution#Contents). For additional details what is in the current release, see the [distribution site](http://software.grid.iu.edu/pacman/cadist/) and [change log](http://software.grid.iu.edu/pacman/cadist/CHANGES).
+Details of CAs in OSG distribution can be found [here](https://twiki.opensciencegrid.org/bin/view/Documentation/CaDistribution#Contents). For additional details what is in the current release, see the [distribution site](http://repo.grid.iu.edu/pacman/cadist/) and [change log](http://repo.grid.iu.edu/pacman/cadist/CHANGES).
 
 ### How can I add or remove a particular CA file?
 
-Add and remove of CA files are supported only if you CA files are being installed using `osg-update-certs`, which is included in the `osg-ca-scripts` package (option 2), for all other options no support for adding and removing a particular CA file is provided by OSG. The preferred approach to add or remove a CA is to use [osg-ca-manage](OsgCaManage). For adding a new CA `osg-ca-manage add [--dir <local_dir>] --hash <CA_hash>` may be used, while a CA is removed using `osg-ca-manage remove --hash <CA_hash>`.
+Add and remove of CA files are supported only if you CA files are being installed using `osg-update-certs`, which is included in the `osg-ca-scripts` package (option 2), for all other options no support for adding and removing a particular CA file is provided by OSG. The preferred approach to add or remove a CA is to use [osg-ca-manage](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/OsgCaManage). For adding a new CA `osg-ca-manage add [--dir <local_dir>] --hash <CA_hash>` may be used, while a CA is removed using `osg-ca-manage remove --hash <CA_hash>`.
 
 ### Are there any log files or configuration files associated with CA certificate package?
 
@@ -416,7 +416,6 @@ Some examples about verifying the certificates:
 
 Related software:
 
--   Description, manual and examples of OsgCaManage
--   OsgCaCertsUpdater
--   [Upgrading Fetch-Crl 2 to Fetch-Crl 3 on EL5](UpgradeFetchCrl2to3)
+-   Description, manual and examples of [osg-ca-manage](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/OsgCaManage)
+-   [osg-ca-certs-updater](ca_updater)
 

--- a/docs/common/ca.md
+++ b/docs/common/ca.md
@@ -53,7 +53,7 @@ Option 2: Install osg-update-certs
 Install this with:
 
 ```
-%UCL_PROMPT_ROOT% yum install osg-ca-scripts
+root@host # yum install osg-ca-scripts
 ```
 
 You have the same choices for CA certificates as above. In order to choose, you will run `osg-ca-manage`, which will install the CA certificates. Then (if desired) you need to enable periodic updating of the CA certificates.
@@ -66,7 +66,7 @@ You have the same choices for CA certificates as above. In order to choose, you 
 Here is an example:
 
 ```
-%UCL_PROMPT_ROOT% /usr/sbin/osg-ca-manage setupCA --location root --url osg
+root@host # /usr/sbin/osg-ca-manage setupCA --location root --url osg
 Setting up CA Certificates for OSG installation
 CA Certificates will be installed into /etc/grid-security/certificates
 osg-update-certs
@@ -82,14 +82,14 @@ Setup completed successfully.
 Initially the CA certificates will not be updated. You can tell by looking at:
 
 ```
-%UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  status
+root@host # /sbin/service osg-update-certs-cron  status
 Periodic osg-update-certs is disabled.
 ```
 
 You can enable the `cron` job that updates the CA certs with:
 
 ```
-%UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  start
+root@host # /sbin/service osg-update-certs-cron  start
 Enabling periodic osg-update-certs:                        [  %GREEN%OK%ENDCOLOR%  ]
 ```
 
@@ -140,9 +140,9 @@ to specifically install it. If you do wish to install it, you can install it as:
 
 ```
 %RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
-%UCL_PROMPT_ROOT% yum install fetch-crl3
+root@host # yum install fetch-crl3
 %RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR%
-%UCL_PROMPT_ROOT% yum install fetch-crl
+root@host # yum install fetch-crl
 ```
 
 ### Enable and Start `fetch-crl`
@@ -151,22 +151,22 @@ To enable fetch-crl (fetch Certificate Revocation Lists) services by default on 
 
 ```
 %RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-boot on
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-cron on
+root@host # /sbin/chkconfig fetch-crl3-boot on
+root@host # /sbin/chkconfig fetch-crl3-cron on
 %RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-boot on
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-cron on
+root@host # /sbin/chkconfig fetch-crl-boot on
+root@host # /sbin/chkconfig fetch-crl-cron on
 ```
 
 To start fetch-crl:
 
 ```
 %RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl3-boot start
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl3-cron start
+root@host # /sbin/service fetch-crl3-boot start
+root@host # /sbin/service fetch-crl3-cron start
 %RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl-boot start
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl-cron start
+root@host # /sbin/service fetch-crl-boot start
+root@host # /sbin/service fetch-crl-cron start
 ```
 
 !!! note
@@ -229,46 +229,46 @@ You need to fetch the latest CA Certificate Revocation Lists (CRLs) and you shou
 
 ```
 %RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /usr/sbin/fetch-crl3 # This fetches the CRLs
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl3-boot start
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl3-cron start
+root@host # /usr/sbin/fetch-crl3 # This fetches the CRLs
+root@host # /sbin/service fetch-crl3-boot start
+root@host # /sbin/service fetch-crl3-cron start
 %RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7%ENDCOLOR%
-%UCL_PROMPT_ROOT% /usr/sbin/fetch-crl # This fetches the CRLs
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl-boot start
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl-cron start
+root@host # /usr/sbin/fetch-crl # This fetches the CRLs
+root@host # /sbin/service fetch-crl-boot start
+root@host # /sbin/service fetch-crl-cron start
 ```
 
 To enable the `fetch-crl` service to keep the CRLs up to date after reboots:
 
 ```
 %RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-boot on
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-cron on
+root@host # /sbin/chkconfig fetch-crl3-boot on
+root@host # /sbin/chkconfig fetch-crl3-cron on
 %RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-boot on
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-cron on
+root@host # /sbin/chkconfig fetch-crl-boot on
+root@host # /sbin/chkconfig fetch-crl-cron on
 ```
 
 To stop `fetch-crl`:
 
 ```
 %RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl3-boot stop
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl3-cron stop
+root@host # /sbin/service fetch-crl3-boot stop
+root@host # /sbin/service fetch-crl3-cron stop
 %RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl-boot stop
-%UCL_PROMPT_ROOT% /sbin/service fetch-crl-cron stop
+root@host # /sbin/service fetch-crl-boot stop
+root@host # /sbin/service fetch-crl-cron stop
 ```
 
 To disable the fetch-crl service:
 
 ```
 %RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-boot off
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-cron off
+root@host # /sbin/chkconfig fetch-crl3-boot off
+root@host # /sbin/chkconfig fetch-crl3-cron off
 %RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR%
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-boot off
-%UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-cron off
+root@host # /sbin/chkconfig fetch-crl-boot off
+root@host # /sbin/chkconfig fetch-crl-cron off
 ```
 
 Updating CAs/CRLs
@@ -286,14 +286,14 @@ How to ensure you are get up-to-date CA/CRL information
 2.  If you use Option 2 (i.e. `osg-update-certs`) then make sure that you have the corresponding service enabled.
 
    ```
-   %UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  status
+   root@host # /sbin/service osg-update-certs-cron  status
    Periodic osg-update-certs is enabled.
    ```
 
 3.  Ensure that fetch-crl cron is enabled\\
 
   ```
-  %UCL_PROMPT_ROOT% /sbin/service fetch-crl-cron  status
+  root@host # /sbin/service fetch-crl-cron  status
   Periodic fetch-crl is enabled.
   ```
 
@@ -332,7 +332,7 @@ Tests
 To test the host certificate of a server `openssl s_client` can be used. Here is an example with the gatekeeper:
 
 ```
-%UCL_PROMPT% openssl s_client -showcerts -cert /etc/grid-security/hostcert.pem -key /etc/grid-security/hostkey.pem -CApath /etc/grid-security/certificates/ -debug -connect osg-gk.mwt2.org:2119
+user@host $ openssl s_client -showcerts -cert /etc/grid-security/hostcert.pem -key /etc/grid-security/hostkey.pem -CApath /etc/grid-security/certificates/ -debug -connect osg-gk.mwt2.org:2119
 ```
 
 Frequently Asked Questions
@@ -384,13 +384,13 @@ For Option 4: run `yum update osg-ca-certs`
 For Option 2: You do not need to do a manual update, make sure `osg-update-certs-cron` is enabled using
 
 ```
-%UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  status
+root@host # /sbin/service osg-update-certs-cron  status
 ```
 
 If the service is disabled, enable it using
 
 ```
-%UCL_PROMPT_ROOT% /sbin/service osg-update-certs-cron  start
+root@host # /sbin/service osg-update-certs-cron  start
 ```
 
 If for some extraordinary reason you need to manually update the CA you could run `osg-ca-manage [--force] refreshCA`.

--- a/docs/common/ca.md
+++ b/docs/common/ca.md
@@ -33,7 +33,7 @@ If you want to install an RPM for one of our predefined CA certificates, you hav
 
 ### Which set of CAs?
 
-1.  (*recommended*) The OSG CA certificates. This is similar to the IGTF set, but may have a small number of additions or deletions. (See [here](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallCertAuth#Contents_of_OSG_CA_package) for details)
+1.  (*recommended*) The OSG CA certificates. This is similar to the IGTF set, but may have a small number of additions or deletions. (See [here](#contents-of-osg-ca-package) for details)
 2.  The default [IGTF](http://www.igtf.net/) CA certificates.
 
 Depending on your choice, you select one of two RPMs:
@@ -66,7 +66,7 @@ You have the same choices for CA certificates as above. In order to choose, you 
 Here is an example:
 
 ```
-%UCL_PROMPT_ROOT% /usr/sbin/osg-ca-manage setupCA --location root --url osg 
+%UCL_PROMPT_ROOT% /usr/sbin/osg-ca-manage setupCA --location root --url osg
 Setting up CA Certificates for OSG installation
 CA Certificates will be installed into /etc/grid-security/certificates
 osg-update-certs
@@ -153,7 +153,7 @@ To enable fetch-crl (fetch Certificate Revocation Lists) services by default on 
 %RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
 %UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-boot on
 %UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl3-cron on
-%RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR% 
+%RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR%
 %UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-boot on
 %UCL_PROMPT_ROOT% /sbin/chkconfig fetch-crl-cron on
 ```
@@ -164,7 +164,7 @@ To start fetch-crl:
 %RED%# For RHEL 5, CentOS 5, and SL5 %ENDCOLOR%
 %UCL_PROMPT_ROOT% /sbin/service fetch-crl3-boot start
 %UCL_PROMPT_ROOT% /sbin/service fetch-crl3-cron start
-%RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR% 
+%RED%# For RHEL 6 or 7, CentOS 6 or 7, and SL6 or SL7 %ENDCOLOR%
 %UCL_PROMPT_ROOT% /sbin/service fetch-crl-boot start
 %UCL_PROMPT_ROOT% /sbin/service fetch-crl-cron start
 ```
@@ -341,7 +341,7 @@ Frequently Asked Questions
 ### Location of Certificates?
 
 ```
- /etc/grid-security/certificates 
+ /etc/grid-security/certificates
 ```
 
 ### What is the version of OSG CA package I have installed and what are its contents?
@@ -418,4 +418,3 @@ Related software:
 
 -   Description, manual and examples of [osg-ca-manage](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/OsgCaManage)
 -   [osg-ca-certs-updater](ca_updater)
-

--- a/docs/common/ca_updater.md
+++ b/docs/common/ca_updater.md
@@ -8,9 +8,9 @@ This document explains the installation and use of `osg-ca-certs-updater`, a pac
 Requirements
 ============
 
--   OS must be Red Hat Enterprise Linux 5 or 6 or variants.
+-   OS must be Red Hat Enterprise Linux 6 or 7 or variants.
 -   The OSG repositories must be installed and enabled. See the [Yum Repositories](yum.md) page for instructions.
--   One grid-certificates package from the OSG repositories must be installed as described [here](ca.md#First_Set_up_the_yum_repositorie). Currently, these are: `igtf-ca-certs`, `osg-ca-certs`.
+-   One grid-certificates package from the OSG repositories must be installed as described [here](ca.md#install-ca-certificates-options). Currently, these are: `igtf-ca-certs`, `osg-ca-certs`.
 
 Install instructions
 ====================
@@ -93,7 +93,7 @@ If logging to syslog via the `-s` / `--log-to-syslog` option, the updater will w
 How to get Help?
 ================
 
-To get assistance please use [Help Procedure](HelpProcedure).
+To get assistance please use [Help Procedure](help).
 
 References
 ==========
@@ -112,7 +112,7 @@ Some examples about verifying the certificates:
 
 Related software:
 
--   [OSG CA certificates](InstallCertAuth)
+-   [OSG CA certificates](ca)
 -   Description, manual and examples of OsgCaManage
 -   OsgCaCertsUpdater
 

--- a/docs/common/cert_scripts.md
+++ b/docs/common/cert_scripts.md
@@ -13,7 +13,7 @@ As an alternative to the web browser interface, these scripts are contributed to
 How to get Help?
 ================
 
-To get assistance please use [Help Procedure](HelpProcedure).
+To get assistance please use [Help Procedure](help).
 
 Requirements
 ============
@@ -44,7 +44,7 @@ Install the certificate scripts package The Cert Scripts package can be installe
 Usage of certificate scripts package This package is mainly used to request certificates via the command line: either host and service certificates or user certificates.
 =========================================================================================================================================================================
 
-[Get host and service certificates using command line](Documentation/Release3.GetHostServiceCertificates)
+[Get host and service certificates using command line](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/GetHostServiceCertificates)
 ---------------------------------------------------------------------------------------------------------
 
 Example usage of check-cert-time The cert-check-time script is helpful in setting up and monitoring the CA certificates and CRL’s that get installed in your trusted certificates directory. This section describes using these scripts to check the CA and CRL status. —+++! Checking CA certificates
@@ -258,17 +258,17 @@ For additional information on the functionality of a script execute it with the 
 
 Files in the package:
 
-| File                                                             | Description                                                                                       |
-|:-----------------------------------------------------------------|:--------------------------------------------------------------------------------------------------|
-| [README](Security.CSReadMe)                                      | describes the package, includes release notes                                                     |
-| [cert-check-time](Security.CSReadMe#cert_check_time)             | checks lifetime of certificates and revocation lists                                              |
-| [cert-gridadmin](Security.CSReadMe#cert_gridadmin)               | immediate issuance of service certificates for authorized requestors                              |
-| [cert-lookup](Security.CSReadMe#cert_lookup)                     | queries directory based on DN of certificates                                                     |
-| [cert-request](Security.CSReadMe#cert_request)                   | generates and submits a certificate signing request                                               |
-| [cert-retrieve](Security.CSReadMe#cert_retrieve)                 | retrieves signed certificate previously requested                                                 |
-| [cert-renew](Security.CSReadMe#cert_renew)                       | renews existing person certificate (not host or service)                                          |
-| [multi-cert-gridadmin](Security.CSReadMe#multi_cert_gridadmin)   | immediate issuance of multiple service certificates for authorized administrators (new with V2-3) |
-| [InstallationNotes.txt](Security.CSReadMe#InstallationNotes_txt) | extra installation requirements for multi-cert-gridadmin (new with V2-3)                          |
+| File                                                                                                        | Description                                                                                       |
+|:------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------|
+| [README](https://twiki.opensciencegrid.org/bin/view/Security/CSReadMe)                                      | describes the package, includes release notes                                                     |
+| [cert-check-time](https://twiki.opensciencegrid.org/bin/view/Security/CSReadMe#cert_check_time)             | checks lifetime of certificates and revocation lists                                              |
+| [cert-gridadmin](https://twiki.opensciencegrid.org/bin/view/Security/CSReadMe#cert_gridadmin)               | immediate issuance of service certificates for authorized requestors                              |
+| [cert-lookup](https://twiki.opensciencegrid.org/bin/view/Security/CSReadMe#cert_lookup)                     | queries directory based on DN of certificates                                                     |
+| [cert-request](https://twiki.opensciencegrid.org/bin/view/Security/CSReadMe#cert_request)                   | generates and submits a certificate signing request                                               |
+| [cert-retrieve](https://twiki.opensciencegrid.org/bin/view/Security/CSReadMe#cert_retrieve)                 | retrieves signed certificate previously requested                                                 |
+| [cert-renew](https://twiki.opensciencegrid.org/bin/view/Security/CSReadMe#cert_renew)                       | renews existing person certificate (not host or service)                                          |
+| [multi-cert-gridadmin](https://twiki.opensciencegrid.org/bin/view/Security/CSReadMe#multi_cert_gridadmin)   | immediate issuance of multiple service certificates for authorized administrators (new with V2-3) |
+| [InstallationNotes.txt](https://twiki.opensciencegrid.org/bin/view/Security/CSReadMe#InstallationNotes_txt) | extra installation requirements for multi-cert-gridadmin (new with V2-3)                          |
 
 FAQ
 ===
@@ -282,7 +282,7 @@ Request a certificate for myself (personal certificate)
 %UCL_PROMPT% cert-request -ou p
 ```
 
-Full details in the [command line document](Documentation/Release3.CertificateGetCmd) or in the [Web interface document](Documentation.CertificateGetWeb) (for a browser based alt.).
+Full details in the [command line document](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/CertificateGetCmd) or in the [Web interface document](https://twiki.opensciencegrid.org/bin/view/Documentation/CertificateGetWeb) (for a browser based alt.).
 
 Request a certificate for my computer (host certificate)
 --------------------------------------------------------
@@ -291,7 +291,7 @@ Request a certificate for my computer (host certificate)
 %UCL_PROMPT% cert-request -ou s
 ```
 
-Full details in the [host and service certificates document](Documentation/Release3.GetHostServiceCertificates).
+Full details in the [host and service certificates document](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/GetHostServiceCertificates).
 
 Request a certificate for the http service on my computer (service certificate)
 -------------------------------------------------------------------------------
@@ -300,7 +300,7 @@ Request a certificate for the http service on my computer (service certificate)
 %UCL_PROMPT% cert-request -ou s -service http -host %RED%my-computer.some.domain%ENDCOLOR% -label %RED%http-my-computer%ENDCOLOR%
 ```
 
-Full details in the [host and service certificates document](Documentation/Release3.GetHostServiceCertificates).
+Full details in the [host and service certificates document](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/GetHostServiceCertificates).
 
 Retrieve a certificate
 ----------------------
@@ -323,5 +323,5 @@ My personal certificate is about to expire, how do I get another with the same D
 
 1.  Use `cert-renew`
 
-Full details in the [command line document](Documentation/Release3.CertificateGetCmd) or in the [Web interface document](Documentation.CertificateGetWeb) (for a browser based alt.).
+Full details in the [command line document](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/CertificateGetCmd) or in the [Web interface document](https://twiki.opensciencegrid.org/bin/view/Documentation/CertificateGetWeb) (for a browser based alt.).
 

--- a/docs/compute-element/htcondor-ce-overview.md
+++ b/docs/compute-element/htcondor-ce-overview.md
@@ -99,7 +99,7 @@ In the OSG, security depends on a PKI infrastructure involving Certificate Autho
 
 Due to the OSG's distributed nature, a user's job may end up at any number of sites, potentially needing to re-authenticate at multiple points. Instead of sending the user's certificate with the job for this re-authentication, trust can be delegated to a proxy that is generated from the user certificate, which is then attached to the job and expires after some set time for added security.
 
-In its default configuration, HTCondor-CE uses GSI-based authentication and authorization (the same as Globus GRAM) to verify the certificate chain, which will work with existing GUMS servers or grid mapfiles. Additionally, it can be reconfigured to provide alternate authentication mechanisms such as Kerberos, SSL, shared secret, or even IP-based authentication. More information about authorization methods can be found [here](http://research.cs.wisc.edu/htcondor/manual/v8.2/3_6Security.html#SECTION00463000000000000000).
+In its default configuration, HTCondor-CE uses GSI-based authentication and authorization (the same as Globus GRAM) to verify the certificate chain, which will work with existing GUMS servers or grid mapfiles. Additionally, it can be reconfigured to provide alternate authentication mechanisms such as Kerberos, SSL, shared secret, or even IP-based authentication. More information about authorization methods can be found [here](http://research.cs.wisc.edu/htcondor/manual/v8.6/3_8Security.html#SECTION00483000000000000000).
 
 Next steps
 ----------

--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -285,7 +285,7 @@ SuppressNoDNRecords="1"
 !!! note
     For HTCondor batch systems only
 
-If you want to provide fairshare on a group basis, as opposed to a Unix user basis, you can use HTCondor accounting groups. They are independent of the Unix groups the user may already be in and are [documented in the HTCondor manual](http://research.cs.wisc.edu/condor/manual/v8.2/3_4User_Priorities.html#SECTION00447000000000000000). If you are using HTCondor accounting groups, you can map jobs from the CE into HTCondor accounting groups based on their UID, their DN, or their VOMS attributes.
+If you want to provide fairshare on a group basis, as opposed to a Unix user basis, you can use HTCondor accounting groups. They are independent of the Unix groups the user may already be in and are [documented in the HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/3_6User_Priorities.html#SECTION00467000000000000000). If you are using HTCondor accounting groups, you can map jobs from the CE into HTCondor accounting groups based on their UID, their DN, or their VOMS attributes.
 
 -   **To map UIDs to an accounting group,** add entries to `/etc/osg/uid_table.txt` with the following form:
 

--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -23,7 +23,7 @@ As with all OSG software installations, there are some one-time (per host) steps
 - Ensure the host has [a supported operating system](../release/supported_platforms)
 - Obtain root access to the host
 - Prepare the [required Yum repositories](../common/yum)
-- Install [CA certificates](https://twiki.grid.iu.edu/bin/view/Documentation/Release3/InstallCertAuth)
+- Install [CA certificates](../common/ca)
 
 Installing HTCondor-CE
 ----------------------
@@ -242,17 +242,17 @@ If you want to limit or disable jobs running locally on your CE, you will need t
 
 The two universes are effectively the same (scheduler universe launches a starter process for each job), so we will be configuring them in unison.
 
-- **To change the default limit** on the number of locally run jobs (the current default is 20), add the following to `/etc/condor-ce/config.d/99-local.conf`: 
+- **To change the default limit** on the number of locally run jobs (the current default is 20), add the following to `/etc/condor-ce/config.d/99-local.conf`:
 
         START_LOCAL_UNIVERSE = TotalLocalJobsRunning + TotalSchedulerJobsRunning < %RED%<JOB-LIMIT>%ENDCOLOR%
         START_SCHEDULER_UNIVERSE = $(START_LOCAL_UNIVERSE)
 
-- **To only allow a specific user** to start locally run jobs, add the following to `/etc/condor-ce/config.d/99-local.conf`: 
+- **To only allow a specific user** to start locally run jobs, add the following to `/etc/condor-ce/config.d/99-local.conf`:
 
         START_LOCAL_UNIVERSE = target.Owner =?= "%RED%<USERNAME>%ENDCOLOR%"
         START_SCHEDULER_UNIVERSE = $(START_LOCAL_UNIVERSE)
 
-- **To disable** locally run jobs, add the following to `/etc/condor-ce/config.d/99-local.conf`: 
+- **To disable** locally run jobs, add the following to `/etc/condor-ce/config.d/99-local.conf`:
 
         START_LOCAL_UNIVERSE = False
         START_SCHEDULER_UNIVERSE = $(START_LOCAL_UNIVERSE)
@@ -347,7 +347,7 @@ In addition to the HTCondor-CE job gateway service itself, there are a number of
 
 | Software          | Service name                          | Notes                                                                                  |
 |:------------------|:--------------------------------------|:---------------------------------------------------------------------------------------|
-| Fetch CRL         | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallCertAuth#Start_Stop_fetch_crl_A_quick_gui) for more info |
+| Fetch CRL         | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](../common/ca/#startstop-fetch-crl-a-quick-guide) for more info |
 | Gratia            | `gratia-probes-cron`                  | Accounting software                                                                    |
 | Your batch system | `condor` or `pbs_server` or …         |                                                                                        |
 | HTCondor-CE       | `condor-ce`                           |                                                                                        |
@@ -445,4 +445,3 @@ Find instructions to request a host certificate [here](https://twiki.grid.iu.edu
 | Htcondor-CE  | tcp      | 9619        | X       |          | HTCondor-CE shared port |
 
 Allow inbound and outbound network connection to all internal site servers, such as GUMS and the batch system head-node only ephemeral outgoing ports are necessary.
-

--- a/docs/compute-element/job_router.md
+++ b/docs/compute-element/job_router.md
@@ -6,7 +6,7 @@ Writing Routes For HTCondor-CE
 About This Guide
 ----------------
 
-The [JobRouter](http://research.cs.wisc.edu/htcondor/manual/v8.2/5_4HTCondor_Job.html) is at the heart of HTCondor-CE and allows admins to transform and direct jobs to specific batch systems. Customizations are made in the form of job routes where each route corresponds to a separate job transformation: If an incoming job matches a job route‘s requirements, the route creates a transformed job (referred to as the ’routed job’) that is then submitted to the batch system. The CE package comes with default routes located in `/etc/condor-ce/config.d/02-ce-*.conf` that provide enough basic functionality for a small site.
+The [JobRouter](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html) is at the heart of HTCondor-CE and allows admins to transform and direct jobs to specific batch systems. Customizations are made in the form of job routes where each route corresponds to a separate job transformation: If an incoming job matches a job route‘s requirements, the route creates a transformed job (referred to as the ’routed job’) that is then submitted to the batch system. The CE package comes with default routes located in `/etc/condor-ce/config.d/02-ce-*.conf` that provide enough basic functionality for a small site.
 
 If you have needs beyond delegating all incoming jobs to your batch system as they are, this document provides examples of common job routes and job route problems.
 
@@ -16,27 +16,25 @@ Quirks and Pitfalls
 -------------------
 
 -   The JobRouter matches jobs to routes in a round-robin fashion. This means that if a job can match to multiple routes, it can be routed by any of them! So when writing job routes, make sure that they are exclusive to each other and that your jobs can only match to a single route.
--   If a value is set in [JOB\_ROUTER\_DEFAULTS](#JobRouterDefaults) with `eval_set_<variable>`, override it by using `eval_set_<variable>` in the `JOB_ROUTER_ENTRIES`. Do this at your own risk as it may cause the CE to break.
+-   If a value is set in [JOB\_ROUTER\_DEFAULTS](#job-router-defaults) with `eval_set_<variable>`, override it by using `eval_set_<variable>` in the `JOB_ROUTER_ENTRIES`. Do this at your own risk as it may cause the CE to break.
 -   Make sure to run `condor_ce_reconfig` after changing your routes, otherwise they will not take effect.
 -   Before the last square bracket, make sure all lines end in a line continuation character (backslash). You can inspect the syntax of your routes with `condor_ce_config_val JOB_ROUTER_ENTRIES` to see if HTCondor-CE has ingested them properly.
--   Do **not** set the [JOB\_ROUTER\_DEFAULTS](#JobRouterDefaults) configuration variable yourself. This will cause the CE to stop functioning.
--   Do **not** set the job environment through the JobRouter. Instead, add any changes to the /etc/osg/config.d/ `[Local Settings]` section and run osg-configure, as documented [here](https://twiki.grid.iu.edu/bin/view/ReleaseDocumentation/ConfigurationFileLocalSettings).
+-   Do **not** set the [JOB\_ROUTER\_DEFAULTS](#job-router-defaults) configuration variable yourself. This will cause the CE to stop functioning.
+-   Do **not** set the job environment through the JobRouter. Instead, add any changes to the /etc/osg/config.d/ `[Local Settings]` section and run osg-configure, as documented [here](../other/configuration-with-osg-configure).
 -   HTCondor batch system only: Local universe jobs are excluded from any routing.
 
 <span class="twiki-macro ENDSECTION"></span>
 
-\#JobRouteConstruction
 
 How Job Routes are Constructed
 ------------------------------
 
-Each job route’s [ClassAd](http://research.cs.wisc.edu/htcondor/manual/v8.2/4_1HTCondor_s_ClassAd.html) is constructed by combining each entry from the `JOB_ROUTER_ENTRIES` with the `JOB_ROUTER_DEFAULTS`. Attributes that are set in `JOB_ROUTER_ENTRIES` will override those set in `JOB_ROUTER_DEFAULTS`
+Each job route’s [ClassAd](http://research.cs.wisc.edu/htcondor/manual/v8.6/4_1HTCondor_s_ClassAd.html) is constructed by combining each entry from the `JOB_ROUTER_ENTRIES` with the `JOB_ROUTER_DEFAULTS`. Attributes that are set in `JOB_ROUTER_ENTRIES` will override those set in `JOB_ROUTER_DEFAULTS`
 
 ### JOB\_ROUTER\_ENTRIES
 
 `JOB_ROUTER_ENTRIES` is a configuration variable whose default is set in `/etc/condor-ce/config.d/02-ce-*.conf` but may be overriden by the administrator in `/etc/condor-ce/config.d/99-local.conf`. This document outlines the many changes you can make to `JOB_ROUTER_ENTRIES` to fit your site’s needs.
 
-\#JobRouterDefaults
 
 ### JOB\_ROUTER\_DEFAULTS
 
@@ -74,7 +72,7 @@ Each job route’s [ClassAd](http://research.cs.wisc.edu/htcondor/manual/v8.2/4_
 
 <span class="twiki-macro ENDTWISTY"></span>
 
-<span class="twiki-macro NOTE"></span> If a value is set in [JOB\_ROUTER\_DEFAULTS](#JobRouterDefaults) with `eval_set_<variable>`, override it by using `eval_set_<variable>` in the `JOB_ROUTER_ENTRIES`. Do this at your own risk as it may cause the CE to break. <span class="twiki-macro NOTE"></span> Do **not** set the `JOB_ROUTER_DEFAULTS` configuration variable yourself. This will cause the CE to stop functioning.
+<span class="twiki-macro NOTE"></span> If a value is set in [JOB\_ROUTER\_DEFAULTS](#job-router-defaults) with `eval_set_<variable>`, override it by using `eval_set_<variable>` in the `JOB_ROUTER_ENTRIES`. Do this at your own risk as it may cause the CE to break. <span class="twiki-macro NOTE"></span> Do **not** set the `JOB_ROUTER_DEFAULTS` configuration variable yourself. This will cause the CE to stop functioning.
 
 Generic Routes
 --------------
@@ -114,7 +112,7 @@ JOB_ROUTER_ENTRIES = [ \
 ]
 ```
 
-The name of the route will be useful in debugging since it shows up in the output of [condor\_ce\_job\_router\_info](Documentation/Release3.TroubleshootingHTCondorCE#condor_ce_job_router_info), the [JobRouterLog](Documentation/Release3.TroubleshootingHTCondorCE#JobRouterLog_AN1), and in the ClassAd of the routed job, which can be viewed with [condor\_ce\_q](Documentation/Release3.TroubleshootingHTCondorCE#condor_ce_q) or [condor\_ce\_history](Documentation/Release3.TroubleshootingHTCondorCE#condor_ce_history).
+The name of the route will be useful in debugging since it shows up in the output of [condor\_ce\_job\_router\_info](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/TroubleshootingHTCondorCE#condor_ce_job_router_info), the [JobRouterLog](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/TroubleshootingHTCondorCE#JobRouterLog_AN1), and in the ClassAd of the routed job, which can be viewed with [condor\_ce\_q](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/TroubleshootingHTCondorCE#condor_ce_q) or [condor\_ce\_history](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/TroubleshootingHTCondorCE#condor_ce_history).
 
 ### Writing multiple routes
 
@@ -160,9 +158,9 @@ JOB_ROUTER_ENTRIES = [ \
 
 ### Setting attributes for all routes
 
-To set an attribute that will be applied to all routes, you will need to use the `[[#SettingAttributes][set_]]` function for each route.
+To set an attribute that will be applied to all routes, you will need to use the [set_](#setting-attributes) function for each route.
 
-<span class="twiki-macro NOTE"></span> Do **not** try to do this by setting the [JOB\_ROUTER\_DEFAULTS](#JobRouterDefaults) configuration variable, as this will cause the CE to stop functioning.
+<span class="twiki-macro NOTE"></span> Do **not** try to do this by setting the [JOB\_ROUTER\_DEFAULTS](#job-router-defaults) configuration variable, as this will cause the CE to stop functioning.
 
 The following routes set the `Periodic_Hold` attribute for both routes:
 
@@ -186,7 +184,7 @@ JOB_ROUTER_ENTRIES = [ \
 
 ### Filtering jobs based on…
 
-To filter jobs, use the `Requirements` attribute. Jobs will evaluate against the ClassAd expression set in the `Requirements` and if the expression evaluates to `TRUE`, the route will match. More information on the syntax of ClassAd's can be found in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.2/4_1HTCondor_s_ClassAd.html). For an example on how incoming jobs interact with filtering in job routes, consult [this document](Documentation.Release3/SubmittingHTCondorCE#Matching).
+To filter jobs, use the `Requirements` attribute. Jobs will evaluate against the ClassAd expression set in the `Requirements` and if the expression evaluates to `TRUE`, the route will match. More information on the syntax of ClassAd's can be found in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/4_1HTCondor_s_ClassAd.html). For an example on how incoming jobs interact with filtering in job routes, consult [this document](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/SubmittingHTCondorCE#Matching).
 
 When setting requirements, you need to prefix job attributes that you are filtering with `TARGET.` so that the job route knows to compare the attribute of the incoming job rather than the route’s own attribute. For example, if an incoming job has a =queue = “analy”= attribute, then the following job route will not match:
 
@@ -199,11 +197,10 @@ JOB_ROUTER_ENTRIES = [ \
 ] 
 ```
 
-This is because when evaluating the route requirement, the job route will compare its own `queue` attribute to “analy” and see that it does not match. You can read more about comparing two ClassAds in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.2/4_1HTCondor_s_ClassAd.html#43151).
+This is because when evaluating the route requirement, the job route will compare its own `queue` attribute to “analy” and see that it does not match. You can read more about comparing two ClassAds in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/4_1HTCondor_s_ClassAd.html#43151).
 
-<span class="twiki-macro NOTE"></span> If you have an HTCondor batch system, note the difference with [set\_requirements](#RoutedReq). <span class="twiki-macro NOTE"></span> The JobRouter matches jobs to routes in a round-robin fashion. This means that if a job can match to multiple routes, it can be routed by any of them! So when writing job routes, make sure that they are exclusive to each other and that your jobs can only match to a single route.
+<span class="twiki-macro NOTE"></span> If you have an HTCondor batch system, note the difference with [set\_requirements](#setting-routed-job-requirements). <span class="twiki-macro NOTE"></span> The JobRouter matches jobs to routes in a round-robin fashion. This means that if a job can match to multiple routes, it can be routed by any of them! So when writing job routes, make sure that they are exclusive to each other and that your jobs can only match to a single route.
 
-\#GlideIn
 
 #### Glidein queue
 
@@ -255,7 +252,7 @@ JOB_ROUTER_ENTRIES = [ \
 
 ### Setting a default…
 
-This section outlines how to set default job limits, memory, cores, queue, and maximum walltime. For an example on how users can override these defaults, consult [this document](Documentation.Release3/SubmittingHTCondorCE#Route_defaults).
+This section outlines how to set default job limits, memory, cores, queue, and maximum walltime. For an example on how users can override these defaults, consult [this document](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/SubmittingHTCondorCE#Route_defaults).
 
 #### Maximum number of jobs
 
@@ -318,9 +315,9 @@ The following functions are operations that affect job attributes and are evalua
 3.  set\_\*
 4.  eval\_set\_\*
 
-After each job route’s ClassAd is [constructed](#JobRouteConstruction), the above operations are evaluated in order. For example, if the attribute `foo` is set using `eval_set_foo` in the `JOB_ROUTER_DEFAULTS`, you‘ll be unable to use `delete_foo` to remote it from your jobs since the attribute is set using `eval_set_foo` after the deletion occurs according to the order of operations. To get around this, we can take advantage of the fact that operations defined in `JOB_ROUTER_DEFAULTS` get overriden by the same operation in `JOB_ROUTER_ENTRIES`. So to ’delete’ `foo`, we would add =eval\_set\_foo = “”= to the route in the `JOB_ROUTER_ENTRIES`, resulting in `foo` being absent from the routed job.
+After each job route’s ClassAd is [constructed](#how-job-routes-are-constructed), the above operations are evaluated in order. For example, if the attribute `foo` is set using `eval_set_foo` in the `JOB_ROUTER_DEFAULTS`, you‘ll be unable to use `delete_foo` to remote it from your jobs since the attribute is set using `eval_set_foo` after the deletion occurs according to the order of operations. To get around this, we can take advantage of the fact that operations defined in `JOB_ROUTER_DEFAULTS` get overriden by the same operation in `JOB_ROUTER_ENTRIES`. So to ’delete’ `foo`, we would add =eval\_set\_foo = “”= to the route in the `JOB_ROUTER_ENTRIES`, resulting in `foo` being absent from the routed job.
 
-More documentation can be found in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.2/5_4HTCondor_Job.html#SECTION00644000000000000000).
+More documentation can be found in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html#SECTION00644000000000000000).
 
 #### Copying attributes
 
@@ -348,7 +345,6 @@ JOB_ROUTER_ENTRIES = [ \
 ] 
 ```
 
-\#SettingAttributes
 
 #### Setting attributes
 
@@ -382,11 +378,11 @@ JOB_ROUTER_ENTRIES = [ \
 
 This section outlines how to limit the number of total or idle jobs in a specific route (i.e., if this limit is reached, jobs will no longer be placed in this route).
 
-<span class="twiki-macro NOTE"></span> If you are using an HTCondor batch system, limiting the number of jobs is not the preferred solution: HTCondor manages fair share on its own via [user priorities and group accounting](http://research.cs.wisc.edu/htcondor/manual/v8.2/3_4User_Priorities.html).
+<span class="twiki-macro NOTE"></span> If you are using an HTCondor batch system, limiting the number of jobs is not the preferred solution: HTCondor manages fair share on its own via [user priorities and group accounting](http://research.cs.wisc.edu/htcondor/manual/v8.6/3_4User_Priorities.html).
 
 #### Total jobs
 
-To set a limit on the number of jobs for a specific route, set the [MaxJobs](http://research.cs.wisc.edu/htcondor/manual/v8.2/5_4HTCondor_Job.html#49135) attribute:
+To set a limit on the number of jobs for a specific route, set the [MaxJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html#49135) attribute:
 
 ``` file
 JOB_ROUTER_ENTRIES = [ \
@@ -405,7 +401,7 @@ JOB_ROUTER_ENTRIES = [ \
 
 #### Idle jobs
 
-To set a limit on the number of idle jobs for a specific route, set the [MaxIdleJobs](http://research.cs.wisc.edu/htcondor/manual/v8.2/5_4HTCondor_Job.html#49136) attribute:
+To set a limit on the number of idle jobs for a specific route, set the [MaxIdleJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html#49136) attribute:
 
 ``` file
 JOB_ROUTER_ENTRIES = [ \
@@ -465,11 +461,10 @@ JOB_ROUTER_ENTRIES = [ \
 ] 
 ```
 
-\#RoutedReq
 
 ### Setting routed job requirements
 
-If you need to set requirements on your routed job, you will need to use `set_Requirements` instead of `Requirements`. The `Requirements` attribute filters jobs coming into your CE into different job routes whereas `set_requirements` will set conditions on the routed job that must be met by the worker node it lands on. For more information on requirements, consult the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.2/2_5Submitting_Job.html#SECTION00352000000000000000).
+If you need to set requirements on your routed job, you will need to use `set_Requirements` instead of `Requirements`. The `Requirements` attribute filters jobs coming into your CE into different job routes whereas `set_requirements` will set conditions on the routed job that must be met by the worker node it lands on. For more information on requirements, consult the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/2_5Submitting_Job.html#SECTION00352000000000000000).
 
 To ensure that your job lands on a Linux machine in your pool:
 
@@ -482,7 +477,7 @@ JOB_ROUTER_ENTRIES = [ \
 
 ### Setting accounting groups
 
-To assign jobs to an HTCondor accounting group to manage fair share on your local batch system, we recommend using [UID and ExtAttr tables](Documentation/Release3.InstallHTCondorCE#AccountingGroups).
+To assign jobs to an HTCondor accounting group to manage fair share on your local batch system, we recommend using [UID and ExtAttr tables](install-htcondor-ce#htcondor-accounting-groups).
 
 Routes for non-HTCondor Batch Systems
 -------------------------------------
@@ -541,7 +536,7 @@ Example Configurations
 
 Atlas AGLT2 is using an HTCondor batch system. Here are some things to note about their routes.
 
--   Setting various HTCondor-specific attributes like `Rank`, `AccountingGroup`, `JobPrio` and `Periodic_Remove` (see the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.2/12_Appendix_A.html) for more). Some of these are site-specific like `LastandFrac`, `IdleMP8Pressure`, `localQue`, `IsAnalyJob` and `JobMemoryLimit`.
+-   Setting various HTCondor-specific attributes like `Rank`, `AccountingGroup`, `JobPrio` and `Periodic_Remove` (see the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/12_Appendix_A.html) for more). Some of these are site-specific like `LastandFrac`, `IdleMP8Pressure`, `localQue`, `IsAnalyJob` and `JobMemoryLimit`.
 -   There is a difference between `Requirements` and `set_requirements`. The `Requirements` attribute matches jobs to specific routes while the `set_requirements` sets the `Requirements` attribute on the *routed* job, which confines which machines that the routed job can land on.
 
 Source: <https://www.aglt2.org/wiki/bin/view/AGLT2/CondorCE#The_JobRouter_configuration_file_content>
@@ -732,8 +727,8 @@ JOB_ROUTER_ENTRIES = \
 
 Atlas BNL T1, they are using an HTCondor batch system. Here are some things to note about their routes:
 
--   Setting various HTCondor-specific attributes like `JobLeaseDuration`, `Requirements` and `Periodic_Hold` (see the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.2/12_Appendix_A.html) for more). Some of these are site-specific like `RACF_Group`, `Experiment`, `Job_Type` and `VO`.
--   Jobs are split into different routes based on the [GlideIn](#GlideIn) queue that they’re in.
+-   Setting various HTCondor-specific attributes like `JobLeaseDuration`, `Requirements` and `Periodic_Hold` (see the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/12_Appendix_A.html) for more). Some of these are site-specific like `RACF_Group`, `Experiment`, `Job_Type` and `VO`.
+-   Jobs are split into different routes based on the [GlideIn](#glidein-queue) queue that they’re in.
 -   There is a difference between `Requirements` and `set_requirements`. The `Requirements` attribute matches *incoming* jobs to specific routes while the `set_requirements` sets the `Requirements` attribute on the *routed* job, which confines which machines that the routed job can land on.
 
 Source: <http://www.usatlas.bnl.gov/twiki/bin/view/Admins/HTCondorCE.html>
@@ -815,8 +810,8 @@ Reference
 
 Here are some other HTCondor-CE documents that might be helpful:
 
--   [HTCondor-CE overview and architecture](HTCondorCEOverview)
--   [Installing HTCondor-CE](InstallHTCondorCE)
--   [The HTCondor-CE troubleshooting guide](TroubleshootingHTCondorCE)
--   [Submitting Jobs to HTCondor-CE](SubmittingHTCondorCE)
+-   [HTCondor-CE overview and architecture](htcondor-ce-overview)
+-   [Installing HTCondor-CE](install-htcondor-ce)
+-   [The HTCondor-CE troubleshooting guide](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/TroubleshootingHTCondorCE)
+-   [Submitting Jobs to HTCondor-CE](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/SubmittingHTCondorCE)
 

--- a/docs/compute-element/job_router.md
+++ b/docs/compute-element/job_router.md
@@ -31,12 +31,12 @@ How Job Routes are Constructed
 
 Each job route’s [ClassAd](http://research.cs.wisc.edu/htcondor/manual/v8.6/4_1HTCondor_s_ClassAd.html) is constructed by combining each entry from the `JOB_ROUTER_ENTRIES` with the `JOB_ROUTER_DEFAULTS`. Attributes that are set in `JOB_ROUTER_ENTRIES` will override those set in `JOB_ROUTER_DEFAULTS`
 
-### JOB\_ROUTER\_ENTRIES
+### JOB_ROUTER_ENTRIES
 
 `JOB_ROUTER_ENTRIES` is a configuration variable whose default is set in `/etc/condor-ce/config.d/02-ce-*.conf` but may be overriden by the administrator in `/etc/condor-ce/config.d/99-local.conf`. This document outlines the many changes you can make to `JOB_ROUTER_ENTRIES` to fit your site’s needs.
 
 
-### JOB\_ROUTER\_DEFAULTS
+### JOB_ROUTER_DEFAULTS
 
 `JOB_ROUTER_DEFAULTS` is a python-generated configuration variable that sets default job route values that are required for the HTCondor-CE’s functionality. To view its contents, run the following command:
 
@@ -197,7 +197,7 @@ JOB_ROUTER_ENTRIES = [ \
 ] 
 ```
 
-This is because when evaluating the route requirement, the job route will compare its own `queue` attribute to “analy” and see that it does not match. You can read more about comparing two ClassAds in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/4_1HTCondor_s_ClassAd.html#43151).
+This is because when evaluating the route requirement, the job route will compare its own `queue` attribute to “analy” and see that it does not match. You can read more about comparing two ClassAds in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/4_1HTCondor_s_ClassAd.html#SECTION00513300000000000000).
 
 <span class="twiki-macro NOTE"></span> If you have an HTCondor batch system, note the difference with [set\_requirements](#setting-routed-job-requirements). <span class="twiki-macro NOTE"></span> The JobRouter matches jobs to routes in a round-robin fashion. This means that if a job can match to multiple routes, it can be routed by any of them! So when writing job routes, make sure that they are exclusive to each other and that your jobs can only match to a single route.
 
@@ -317,7 +317,7 @@ The following functions are operations that affect job attributes and are evalua
 
 After each job route’s ClassAd is [constructed](#how-job-routes-are-constructed), the above operations are evaluated in order. For example, if the attribute `foo` is set using `eval_set_foo` in the `JOB_ROUTER_DEFAULTS`, you‘ll be unable to use `delete_foo` to remote it from your jobs since the attribute is set using `eval_set_foo` after the deletion occurs according to the order of operations. To get around this, we can take advantage of the fact that operations defined in `JOB_ROUTER_DEFAULTS` get overriden by the same operation in `JOB_ROUTER_ENTRIES`. So to ’delete’ `foo`, we would add =eval\_set\_foo = “”= to the route in the `JOB_ROUTER_ENTRIES`, resulting in `foo` being absent from the routed job.
 
-More documentation can be found in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html#SECTION00644000000000000000).
+More documentation can be found in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html).
 
 #### Copying attributes
 
@@ -378,11 +378,11 @@ JOB_ROUTER_ENTRIES = [ \
 
 This section outlines how to limit the number of total or idle jobs in a specific route (i.e., if this limit is reached, jobs will no longer be placed in this route).
 
-<span class="twiki-macro NOTE"></span> If you are using an HTCondor batch system, limiting the number of jobs is not the preferred solution: HTCondor manages fair share on its own via [user priorities and group accounting](http://research.cs.wisc.edu/htcondor/manual/v8.6/3_4User_Priorities.html).
+<span class="twiki-macro NOTE"></span> If you are using an HTCondor batch system, limiting the number of jobs is not the preferred solution: HTCondor manages fair share on its own via [user priorities and group accounting](http://research.cs.wisc.edu/htcondor/manual/v8.6/3_6User_Priorities.html).
 
 #### Total jobs
 
-To set a limit on the number of jobs for a specific route, set the [MaxJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html#49135) attribute:
+To set a limit on the number of jobs for a specific route, set the [MaxJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html#SECTION00644000000000000000) attribute:
 
 ``` file
 JOB_ROUTER_ENTRIES = [ \
@@ -401,7 +401,7 @@ JOB_ROUTER_ENTRIES = [ \
 
 #### Idle jobs
 
-To set a limit on the number of idle jobs for a specific route, set the [MaxIdleJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html#49136) attribute:
+To set a limit on the number of idle jobs for a specific route, set the [MaxIdleJobs](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html#SECTION00644000000000000000) attribute:
 
 ``` file
 JOB_ROUTER_ENTRIES = [ \
@@ -464,7 +464,7 @@ JOB_ROUTER_ENTRIES = [ \
 
 ### Setting routed job requirements
 
-If you need to set requirements on your routed job, you will need to use `set_Requirements` instead of `Requirements`. The `Requirements` attribute filters jobs coming into your CE into different job routes whereas `set_requirements` will set conditions on the routed job that must be met by the worker node it lands on. For more information on requirements, consult the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/2_5Submitting_Job.html#SECTION00352000000000000000).
+If you need to set requirements on your routed job, you will need to use `set_Requirements` instead of `Requirements`. The `Requirements` attribute filters jobs coming into your CE into different job routes whereas `set_requirements` will set conditions on the routed job that must be met by the worker node it lands on. For more information on requirements, consult the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/2_5Submitting_Job.html#SECTION00357000000000000000).
 
 To ensure that your job lands on a Linux machine in your pool:
 

--- a/docs/data/gridftp.md
+++ b/docs/data/gridftp.md
@@ -156,7 +156,7 @@ In addition to the GridFTP service itself, there are a number of supporting serv
 
 | Software  | Service name                          | Notes                                                                                  |
 |:----------|:--------------------------------------|:---------------------------------------------------------------------------------------|
-| Fetch CRL | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallCertAuth#Start_Stop_fetch_crl_A_quick_gui) for more info |
+| Fetch CRL | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](../common/ca/#startstop-fetch-crl-a-quick-guide) for more info |
 | Gratia    | `gratia-probes-cron`                  | Accounting software                                                                    |
 | GridFTP   | `globus-gridftp-server`               |                                                                                        |
 
@@ -225,4 +225,3 @@ For more details on overall firewall configuration, please see our [firewall doc
 | GridFTP data channels   | tcp      | `GLOBUS_TCP_PORT_RANGE`   | X       |          | contiguous range of ports is necessary. |
 | GridFTP data channels   | tcp      | `GLOBUS_TCP_SOURCE_RANGE` |         | X        | contiguous range of ports is necessary. |
 | GridFTP control channel | tcp      | 2811                      | X       |          |                                         |
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@ OSG Site Administrator Documentation
 ====================================
 
 !!! note
-    The documentation contained here is currently a work in progress as we migrate our TWiki documentation to GitHub. Please let us know of any issues that you encounter by [opening a ticket](https://ticket.opensciencegrid.org) or e-mailing [goc@opensciencegrid.org](goc@opensciencegrid.org). Please identify errors, inconsistencies, or incorrect information in the documentation, and also suggest extra content that you feel would be helpful to include in the documentation.
+    The documentation contained here is currently a work in progress as we migrate our TWiki documentation to GitHub. Please let us know of any issues that you encounter by [opening a ticket](https://ticket.opensciencegrid.org) or e-mailing [goc@opensciencegrid.org](mailto:goc@opensciencegrid.org). Please identify errors, inconsistencies, or incorrect information in the documentation, and also suggest extra content that you feel would be helpful to include in the documentation.
 
 Welcome to the home page of the Open Science Grid (OSG) Site Administrator documentation! If you're a new OSG site adminstrator, start with the [Installation Overview](install-overview). If you are not a site adminstrator...
 

--- a/docs/install-overview.md
+++ b/docs/install-overview.md
@@ -40,7 +40,7 @@ If necessary, provision all OSG hosts that are in your site plan and that do not
 
 ### Installing and Managing Certificates for Site Security ###
 
--   [Installing the grid certificate authorities (CAs)](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallCertAuth)
+-   [Installing the grid certificate authorities (CAs)](common/ca)
 -   [How do I get PKI host and service X.509 certificates?](https://twiki.grid.iu.edu/bin/view/ReleaseDocumentation/GetHostServiceCertificates)
 -   [Automatically updating the grid certificate authorities (CAs)](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/OsgCaCertsUpdater)
 -   [SHA-2 certificates and minimum required OSG software versions](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/SHA2Compliance)

--- a/docs/monitoring/rsv-gwms-tester.md
+++ b/docs/monitoring/rsv-gwms-tester.md
@@ -14,8 +14,8 @@ Before Starting
 
 Before starting the installation process, consider the following points (consulting [the Reference section below](#ReferenceSection) as needed):
 
-- **Software:** You must have [a GlideinWMS Front-end](InstallGlideinWMSFrontend) installed
-- **Configuration:** The GlideinWMS Front-end must be configured (a) [to have at least one group that matches pilots to sites using DESIRED_SITES](InstallGlideinWMSFrontend#DesiredSites), and (b) [to support the is_itb user job attribute](InstallGlideinWMSFrontend#IsItb)
+- **Software:** You must have [a GlideinWMS Front-end](../other/install-gwms-frontend) installed
+- **Configuration:** The GlideinWMS Front-end must be configured (a) [to have at least one group that matches pilots to sites using DESIRED_SITES](../other/install-gwms-frontend#allow-users-to-specify-where-their-jobs-run), and (b) [to support the is_itb user job attribute](../other/install-gwms-frontend#creating-a-group-for-testing-configuration-changes)
 - **Host choice:** The Tester should be installed on its own host; a small Virtual Machine (VM) is ideal
 - **Service certificate:** The Tester requires a host certificate at `/etc/grid-security/hostcert.pem` and an accompanying key at `/etc/grid-security/hostkey.pem`
 - **Network ports:** Test jobs must be able to contact the tester using the HTCondor Shared Port on port 9615 (TCP), and you must be able to contact a web server on port 80 (TCP) to view test results.
@@ -186,7 +186,7 @@ The highlighted name is the site name, and there should be one such line per sit
 Troubleshooting RSV-GWMS-Tester
 -------------------------------
 
-You can find more information on troubleshooting in the [RSV troubleshooting section](https://twiki.grid.iu.edu/bin/view/Documentation/Release3/InstallRSV#Troubleshooting_RSV)
+You can find more information on troubleshooting in the [RSV troubleshooting section](../monitoring/rsv#troubleshooting-rsv)
 
 Logs and configuration:
 
@@ -208,9 +208,10 @@ Reference
 
 ### Certificates
 
-| Certificate      | User that owns certificate | Path to certificate                                                           |
-|:-----------------|:---------------------------|:------------------------------------------------------------------------------|
-| Host certificate | `root`                     | `/etc/grid-security/hostcert.pem` &lt;br&gt; `/etc/grid-security/hostkey.pem` |
+| Certificate      | User that owns certificate | Path to certificate               |
+|:-----------------|:---------------------------|:----------------------------------|
+| Host certificate | `root`                     | `/etc/grid-security/hostcert.pem` |
+| Host key         | `root`                     | `/etc/grid-security/hostkey.pem`  |
 
 Find instructions to request a host certificate [here](../common/pki-cli.md).
 

--- a/docs/monitoring/rsv.md
+++ b/docs/monitoring/rsv.md
@@ -35,7 +35,7 @@ As with all OSG software installations, there are some one-time (per host) steps
 - Ensure the RSV host has [a supported operating system](../common/yum.md)
 - Obtain root access to the host
 - Prepare [the required Yum repositories](../common/yum.md)
-- Install [CA certificates](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallCertAuth)
+- Install [CA certificates](../common/ca)
 
 Installing RSV
 --------------
@@ -53,19 +53,19 @@ An installation of RSV at a site consists of the RSV client software, the Apache
 
 2. If you have installed HTCondor already but not by RPM, install a special empty RPM to make RSV happy:
 
-        :::console   
+        :::console
         [root@client ~] # yum install empty-condor --enablerepo=osg-empty
 
-3. Install RSV and related software: 
+3. Install RSV and related software:
 
         :::console
-        [root@client ~] # yum install rsv  
-   
+        [root@client ~] # yum install rsv
+
 Configuring RSV
 ---------------
- 
+
 After installation, there are some one-time configuration steps to tell RSV how to operate at your site.
- 
+
 1. Edit `/etc/osg/config.d/30-rsv.ini` and follow the instructions in the file. There are detailed comments for each setting. In the simplest case — to monitor only your CE — set the `htcondor_ce_hosts` variable to the fully qualified hostname of your CE.
 
 2. If you have installed HTCondor already but not by RPM, specify the location of the Condor installation in `30-rsv.ini` in the `condor_location` setting. If an HTCondor RPM is installed, you do not need to set `condor_location`.
@@ -117,14 +117,14 @@ If you would like your local RSV web server to use HTTPS instead of the default 
 
         :::file
         Listen 8000
-        
+
 
 5. Set up HTTPS access by editing `/etc/httpd/conf.d/ssl.conf`:
 
         :::file
         Listen 8443
         <VirtualHost _default_:8443>
-        SSLCertificateFile /etc/grid-security/http/httpcert2.pem	
+        SSLCertificateFile /etc/grid-security/http/httpcert2.pem
         SSLCertificateKeyFile /etc/grid-security/http/httpkey2.pem
 
     After these changes, when you start the Apache service, it will listening on ports `8000` (for HTTP) and `8443` (for HTTPS), rather than the default port `80` (for HTTP only).
@@ -142,7 +142,7 @@ In addition to the RSV service itself, there are a number of supporting services
 
 | Software      | Service name                                   | Notes                   |
 |:--------------|:-----------------------------------------------|------------------------ |
-| Fetch CRL     | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallCertAuth#Start_Stop_fetch_crl_A_quick_gui)|
+| Fetch CRL     | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](../common/ca/#startstop-fetch-crl-a-quick-guide)|
 | Apache        | httpd                                          |                         |
 | HTCondor-Cron | condor-cron                                    |                         |
 | RSV           | rsv                                            |                         |
@@ -201,13 +201,13 @@ The first step to getting more information is to run rsv-control with more verbo
 - 2 = adds informational messages
 - 3 = full debugging output
 
-For example, here is the output when running a metric with -v2. 
+For example, here is the output when running a metric with -v2.
 
-<details> 
+<details>
   <summary>Show detailed ouput</summary>
    <p>
 ```console
-   [root@fermicloud016 condor]# rsv-control -r org.osg.general.osg-version -v 2 -u osg-edu.cs.wisc.edu 
+   [root@fermicloud016 condor]# rsv-control -r org.osg.general.osg-version -v 2 -u osg-edu.cs.wisc.edu
    INFO: Reading configuration file /etc/rsv/rsv.conf
    INFO: Reading configuration file /etc/rsv/consumers.conf
    INFO: Validating configuration:
@@ -298,7 +298,7 @@ The RSV installation will create two users unless they are already created. The 
 !!! warning
 
     If you manage your `/etc/passwd` file with configuration management software such as Puppet, CFEngine or 411, make sure the UID and GID in `/etc/condor-cron/config.d/condor_ids` matches the UID and GID of the `cndrcron` user and group in `/etc/passwd`. If it does not, create a file named `/etc/condor-cron/config.d/condor_ids_override` with the contents:
-   
+
 
 ```file
 CONDOR_IDS=UID.GID
@@ -323,7 +323,7 @@ See [instructions](../common/pki-cli.md) to request a service certificate.
 
 | Service Name  | Protocol    |Port Number | Inbound | Outbound | Comment |
 |:--------------|:------------|:-----------|:--------|:---------|:--------|
-| HTTP          | tcp         | 80         |   YES   |          | RSV runs an HTTP server (Apache) that publishes a page with the RSV testing results | 
+| HTTP          | tcp         | 80         |   YES   |          | RSV runs an HTTP server (Apache) that publishes a page with the RSV testing results |
 | HTTP          | tcp         | 80         |         | YES      | RSV pushes testing results to the OSG Gratia Collectors at opensciencegrid.org  |
 | various       | various     | various    |  	     | YES      | Allow outbound network connection to all services that you want to test        |
 

--- a/docs/other/gsissh.md
+++ b/docs/other/gsissh.md
@@ -16,10 +16,6 @@ Users and Groups
 
 The RPM installation will try to create the `gsisshd` user and group and the `/var/empty/gsisshd` directory with the correct ownership if they are not present. If you are using a configuration management system or ROCKS, you should make sure that these users and groups are created before installing the RPMs to avoid potential issues. The gsisshd user should have an empty home directory. By default, this is home directory set to `/var/empty/gsisshd` and belongs to the `gsisshd` user and group. You may change it if needed to something else as long as the ownerships remain the same.
 
-Networking
-----------
-
-You'll find more client specific details also in the [Firewall section](#Firewall_Considerations) of this document.
 
 Installation procedure
 ======================
@@ -33,8 +29,8 @@ GSI OpenSSH Installation
 
 Start with installing GSI OpenSSH from the repository
 
-``` rootscreen
-yum install gsi-openssh-server gsi-openssh-clients
+``` console
+[root@server]# yum install gsi-openssh-server gsi-openssh-clients
 ```
 
 In addition, you'll need to install CA certificates in order for GSIOpenSSH to work. You can follow the instructions below in order to install them:
@@ -64,11 +60,9 @@ Other Files
 | Service or Process | File                              | Description      |
 |:-------------------|:----------------------------------|:-----------------|
 | gsisshd            | `/etc/grid-security/hostcert.pem` | Host certificate |
-| gsisshd            | `/etc/grid-security/hostcert.pem` | Key certificate  |
+| gsisshd            | `/etc/grid-security/hostkey.pem`  | X.509 host key   |
 | gsisshd            | `/etc/gsissh/ssh_host_rsa_key`    | RSA Host key     |
 
-Configuration
--------------
 Configuration
 -------------
 In order to get a running instance of the GSI OpenSSH server, you'll
@@ -104,7 +98,7 @@ of the lines in the file are commented out using a `#` at the beginning of the l
 
 An example of the `/etc/grid-security/grid-mapfile` follows:
 
-``` file
+```
 "/DC=org/DC=doegrids/OU=People/CN=USER NAME 123456" useraccount
 ```
 
@@ -113,14 +107,14 @@ Using LCMAPS and GUMS for authorization
 
 In order to use LCMAPS callouts with GSI OpenSSH, you'll first need to edit `/etc/grid-security/gsi-authz.conf` to indicate that Globus should do a GSI callout for authorization. The file should contain the following:
 
-``` file
+```
 globus_mapping liblcas_lcmaps_gt4_mapping.so lcmaps_callout
 ```
 
 so that LCMAPS is used. Next, install the lcmaps rpms:
 
-``` rootscreen
-yum install lcmaps lcas-lcmaps-gt4-interface
+``` console
+[root@server]# yum install lcmaps lcas-lcmaps-gt4-interface
 ```
 
 Finally, you'll need to modify `/etc/lcmaps.db` so that the `gumsclient` entry has the correct endpoint for your gums server.
@@ -197,5 +191,5 @@ $
 How to get Help?
 ================
 
-To get assistance please use this [Help Procedure](HelpProcedure).
+To get assistance please use this [Help Procedure](../common/help).
 

--- a/docs/other/install-gwms-frontend.md
+++ b/docs/other/install-gwms-frontend.md
@@ -155,7 +155,7 @@ Refer to installtion of the [InstallCertAuth](../common/ca)
 Install HTCondor
 ----------------
 
-Most required software is installed from the Frontend RPM installation. HTCondor is the only exception since there are [many different ways to install it](CondorInformation), using the RPM system or not. You need to have HTCondor installed before installing the Glidein WMS Frontend. If yum cannot find a HTCondor RPM, it will install the dummy `empty-condor` RPM, assuming that you installed HTCondor using a tarball distribution.
+Most required software is installed from the Frontend RPM installation. HTCondor is the only exception since there are [many different ways to install it](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/CondorInformation), using the RPM system or not. You need to have HTCondor installed before installing the Glidein WMS Frontend. If yum cannot find a HTCondor RPM, it will install the dummy `empty-condor` RPM, assuming that you installed HTCondor using a tarball distribution.
 
 If you don't have HTCondor already installed, you can install the HTCondor RPM from the OSG repository:
 
@@ -974,7 +974,7 @@ Documents about the Glidein-WMS system and the VO frontend:
 
 -   <http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/>
 -   <http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/doc.prd/manual/>
--   [How to setup a Submit host flocking to the VO Frontend](GlideinWMSCampusGrid)
+-   [How to setup a Submit host flocking to the VO Frontend](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/GlideinWMSCampusGrid)
 
 
 

--- a/docs/other/install-gwms-frontend.md
+++ b/docs/other/install-gwms-frontend.md
@@ -39,8 +39,8 @@ Requirements
 Host and OS
 -----------
 
-1. A host to install the GlideinWMS Frontend (pristine node). 
-2. OS is Red Hat Enterprise Linux 6, 7, and variants (see [details](../common/yum.md)). Currently most of our testing has been done on Scientific Linux 6. 
+1. A host to install the GlideinWMS Frontend (pristine node).
+2. OS is Red Hat Enterprise Linux 6, 7, and variants (see [details](../common/yum.md)). Currently most of our testing has been done on Scientific Linux 6.
 3. Root access
 
 The Glidein WMS VO Frontend has the following hardware requirements for a production host:
@@ -66,9 +66,9 @@ Note that if uid 48 is already taken but not used for the appropriate users, you
 Credentials and Proxies
 -----------------------
 
-The VO Frontend will use two credentials in its interactions with the the other glideinWMS services. At this time, these will be proxy files. 
+The VO Frontend will use two credentials in its interactions with the the other glideinWMS services. At this time, these will be proxy files.
 
-1. the %GREEN%VO Frontend proxy%ENDCOLOR% (used to authenticate with the other glideinWMS services). 
+1. the %GREEN%VO Frontend proxy%ENDCOLOR% (used to authenticate with the other glideinWMS services).
 2. one or more glideinWMS %RED%pilot proxies%ENDCOLOR% (used/delegated to the factory services and submitted on the glideinWMS pilot jobs).
 
 The %GREEN%VO Frontend proxy%ENDCOLOR% and the %RED% pilot proxy%ENDCOLOR% can be the same. By default, the VO Frontend will run as user `frontend` (UID is machine dependent) so these proxies must be owned by the user `frontend`.
@@ -103,7 +103,7 @@ Networking
 |:------------------|:---------|:-----------------|:------|:-------|-------------------------|
 |HTCondor port range| tcp      |`LOWPORT, HIGHPORT`|`YES` |        |contiguous range of ports|
 |GlideinWMS Frontend| tcp      | 9618 to 9660     |`YES`  |        |HTCondor Collectors for the GlideinWMS Frontend (received ClassAds from resources and jobs)|
- 
+
 The VO frontend must have reliable network connectivity, be on the public internet (no NAT), and preferably with no firewalls. Each running pilot requires 5 outgoing TCP ports. Incoming TCP ports 9618 to 9660 must be open.
 
 -   For example, 2000 running jobs require about 10,100 TCP connections. This will overwhelm many firewalls; if you are unfamiliar with your network topology, you may want to warn your network administrator.
@@ -119,38 +119,38 @@ Once all requirements are satisfied you must take a couple of actions before ins
 OSG Factory access
 ------------------
 
-Before installing the Glidein WMS VO Frontend you need the information about a [Glidein Factory](http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/doc.prd/factory/index.html) that you can access: 
+Before installing the Glidein WMS VO Frontend you need the information about a [Glidein Factory](http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/doc.prd/factory/index.html) that you can access:
 
-1. (recommended) OSG is managing a factory at UCSD and one at GOC and you can request access to them 
+1. (recommended) OSG is managing a factory at UCSD and one at GOC and you can request access to them
 2. You have another Glidein Factory that you can access
 3. You [install your own Glidein Factory](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallGlideinWMSFactory)
 
-To request access to the OSG Glidein Factory at UCSD you have to send an email to <osg-gfactory-support@physics.ucsd.edu> providing: 
+To request access to the OSG Glidein Factory at UCSD you have to send an email to <osg-gfactory-support@physics.ucsd.edu> providing:
 
-1. Your Name 
+1. Your Name
 2. The VO that is utilizing the VO Frontend
-3. The DN of the proxy you will use to communicate with the Factory (VO Frontend DN, e.g. the host certificate subject if you follow the [proxy configuration section](#proxy-configuration)) 
-4. You can propose a security name that will have to be confirmed/changed by the Factory managers (see below) 
+3. The DN of the proxy you will use to communicate with the Factory (VO Frontend DN, e.g. the host certificate subject if you follow the [proxy configuration section](#proxy-configuration))
+4. You can propose a security name that will have to be confirmed/changed by the Factory managers (see below)
 5. A list of sites where you want to run:
 
 - Your VO must be supported on those sites
 - You can provide a list or piggy back on existing lists, e.g. all the sites supported for the VO. Check with the Factory managers
 - You can start with one single site
 
-In the reply from the OSG Factory managers you will receive some information needed for the configuration of your VO Frontend 
+In the reply from the OSG Factory managers you will receive some information needed for the configuration of your VO Frontend
 
-1. The exact spelling and capitalization of your VO name. Sometime is different from what is commonly used, e.g. OSG VO is "OSGVO". 
+1. The exact spelling and capitalization of your VO name. Sometime is different from what is commonly used, e.g. OSG VO is "OSGVO".
 2. The host of the Factory Collector: `gfactory-1.t2.ucsd.edu`
-3. The DN os the factory, e.g. `/DC=org/DC=doegrids/OU=Services/CN=gfactory-1.t2.ucsd.edu` 
-4. The factory identity, e.g.: `gfactory@gfactory-1.t2.ucsd.edu` 
-5. The identity on the factory you will be mapped to. Something like: `username@gfactory-1.t2.ucsd.edu` 
+3. The DN os the factory, e.g. `/DC=org/DC=doegrids/OU=Services/CN=gfactory-1.t2.ucsd.edu`
+4. The factory identity, e.g.: `gfactory@gfactory-1.t2.ucsd.edu`
+5. The identity on the factory you will be mapped to. Something like: `username@gfactory-1.t2.ucsd.edu`
 6. Your security name. A unique name, usually containing your VO name: `My_SecName`
 7. A string to add in the main factory query\_expr in the frontend configuration, e.g. `stringListMember("%RED%VO%ENDCOLOR%",GLIDEIN_Supported_VOs)`. From there you get the correct name of the VO (above in this list).
 
 Installation Procedure
 ======================
 
-Refer to installtion of the [InstallCertAuth](../common/ca)
+Refer to installation of the [CA certificates](../common/ca)
 
 Install HTCondor
 ----------------
@@ -228,7 +228,7 @@ If you have a working installation of glideinwms-frontend you can just upgrade t
     When you do a generic yum update that will update also condor, the upgrade may restore the personal condor config file that you have to remove with `rm /etc/condor/config.d/00personal_condor.config`
 
 !!! note
-    When upgrading to GlideinWMS 3.2.7 the second schedd is removed from the default configuration. For a smooth transition: 
+    When upgrading to GlideinWMS 3.2.7 the second schedd is removed from the default configuration. For a smooth transition:
 
     1. remove from **`/etc/gwms-frontend/frontend.xml`** the second schedd (the line containing **`schedd_jobs2@YOUR_HOST`**)
     2. reconfigure the frontend (`service gwms-frontend reconfig`)
@@ -286,12 +286,12 @@ The VO Frontend configuration file is `/etc/gwms-frontend/frontend.xml`. The nex
         <factory query_expr='((stringListMember("VO", GLIDEIN_Supported_VOs)))'>
 
 2. Factory collector information. The `username` that you are assigned by the factory (also called the identity you will be mapped to on the factory, see above) . Note that if you are using a factory different than the production factory, you will have to change also `DN`, `factory_identity` and `node` attributes. (refer to the information provided to you by the factory operator):
-   
+
         :::file
-        <collector DN="/DC=org/DC=doegrids/OU=Services/CN=gfactory-1.t2.ucsd.edu" 
-                   comment="Define factory collector globally for simplicity" 
-                   factory_identity="gfactory@gfactory-1.t2.ucsd.edu" 
-                   my_identity="username@gfactory-1.t2.ucsd.edu" 
+        <collector DN="/DC=org/DC=doegrids/OU=Services/CN=gfactory-1.t2.ucsd.edu"
+                   comment="Define factory collector globally for simplicity"
+                   factory_identity="gfactory@gfactory-1.t2.ucsd.edu"
+                   my_identity="username@gfactory-1.t2.ucsd.edu"
                    node="gfactory-1.t2.ucsd.edu"/>
 
 3. Frontend security information.
@@ -301,16 +301,16 @@ The VO Frontend configuration file is `/etc/gwms-frontend/frontend.xml`. The nex
     - The `security_name` identifies this VO Frontend to the the Factory, It is provided by the factory operator.
     - The `absfname` in the credential (or proxy in v 2.x) entry is the location of the glideinWMS %RED%`pilot`%ENDCOLOR% proxy described in the requirements section [here](#credentials-and-proxies). There can be multiple pilot proxies, or even other kind of keys (e.g. if you use cloud resources). ***The type and trust_domain of the credential must match respectively auth_method and trust_domain used in the entry definition in the factory. If there is no match, between these two attributes in one of the credentials and some entry in one of the factories, then this frontend cannot trigger glideins.***
 Both the `classad_proxy` and `absfname` files should be owned by `frontend` user.
-        
- 
+
+
             :::file
             # These lines are from the configuration of v 3.x
-            <security classad_proxy="/tmp/vo_proxy" proxy_DN="DN of vo_proxy" 
-                  proxy_selection_plugin="ProxyAll" 
-                  security_name="The security name, this is used by factory" 
+            <security classad_proxy="/tmp/vo_proxy" proxy_DN="DN of vo_proxy"
+                  proxy_selection_plugin="ProxyAll"
+                  security_name="The security name, this is used by factory"
                   sym_key="aes_256_cbc">
                   <credentials>
-                    <credential absfname="/tmp/pilot_proxy" security_class="frontend" 
+                    <credential absfname="/tmp/pilot_proxy" security_class="frontend"
                     trust_domain="OSG" type="grid_proxy"/>
                   </credentials>
             </security>
@@ -339,15 +339,15 @@ Both the `classad_proxy` and `absfname` files should be owned by `frontend` user
 
      The default Condor configuration of the VO Frontend starts multiple Collector processes on the host (`/etc/condor/config.d/11_gwms_secondary_collectors.config`). The `DN` and `hostname` on the first line are the hostname and the host certificate of the VO Frontend. The `DN` and `hostname` on the second line are the same as the ones in the first one. The hostname (e.g. hostname.domain.tld) is filled automatically during the installation. The secondary collector ports can be defined as a range, e.g., 9620-9660).
 
-            
-            <collector DN="DN of main collector" 
+
+            <collector DN="DN of main collector"
                    node="hostname.domain.tld:9618" secondary="False"/>
-            <collector DN="DN of secondary collectors (usually same as DN in line above)" 
+            <collector DN="DN of secondary collectors (usually same as DN in line above)"
                    node="hostname.domain.tld:9620-9660" secondary="True"/>
 
 !!! warning
-    The Frontend configuration includes many knobs, some of which are conflicting with a RPM installation where there is only one version of the Frontend installed and it uses well known paths.     Do not change the following in the Frontend configuration (you must leave the default values coming with the RPM installation):   
-      
+    The Frontend configuration includes many knobs, some of which are conflicting with a RPM installation where there is only one version of the Frontend installed and it uses well known paths.     Do not change the following in the Frontend configuration (you must leave the default values coming with the RPM installation):
+
        - frontend_versioning='False' (in the first line of XML, versioning is useful to install multiple tarball versions)
        - work base_dir must be /var/lib/gwms-frontend/vofrontend/ (other scripts like /etc/init.d/gwms-frontend count on that value)
 
@@ -361,11 +361,11 @@ The configuration above points to the OSG production Factory. If you are using a
 Configuring Condor
 ------------------
 
-The condor configuration for the frontend is placed in `/etc/condor/config.d`. 
+The condor configuration for the frontend is placed in `/etc/condor/config.d`.
 
-- 00_gwms_general.config 
-- 01_gwms_collectors.config 
-- 02_gwms_schedds.config 
+- 00_gwms_general.config
+- 01_gwms_collectors.config
+- 02_gwms_schedds.config
 - 03_gwms_local.config
 - 11_gwms_secondary_collectors.config
 - 90_gwms_dns.config
@@ -380,7 +380,7 @@ For most installations create a new file named `/etc/condor/config.d/92_local_co
 
 ### Using other Condor RPMs, e.g. UW Madison HTCondor RPM
 
-The above procedure will work if you are using the OSG HTCondor RPMS. You can verify that you used the OSG HTCondor RPM by using `yum list condor`. The version name should include "osg", e.g. `7.8.6-3.osg.el5`. 
+The above procedure will work if you are using the OSG HTCondor RPMS. You can verify that you used the OSG HTCondor RPM by using `yum list condor`. The version name should include "osg", e.g. `7.8.6-3.osg.el5`.
 
 If you are using the UW Madison Condor RPMS, be aware of the following changes:
 
@@ -388,19 +388,19 @@ If you are using the UW Madison Condor RPMS, be aware of the following changes:
 -   If you want to disable this behavior (recommended), you should blank out that file or comment out the line in `/etc/condor/condor_config` for LOCAL\_CONFIG\_FILE. (Make sure that LOCAL\_CONFIG\_DIR is set to `/etc/condor/config.d`)
 -   Note that the variable LOCAL\_DIR is set differently in UW Madison and OSG RPMs. This should not cause any more problems in the glideinwms RPMs, but please take note if you use this variable in your job submissions or other customizations.
 
-In general if you are using a non OSG RPM or if you added custom configuration files for HTCondor please check the order of the configuration files: 
+In general if you are using a non OSG RPM or if you added custom configuration files for HTCondor please check the order of the configuration files:
 
     :::console
-    [root@client ~] # condor_config_val -config 
-    Configuration source: 
-        /etc/condor/condor_config 
-    Local configuration sources: 
+    [root@client ~] # condor_config_val -config
+    Configuration source:
+        /etc/condor/condor_config
+    Local configuration sources:
         /etc/condor/config.d/00_gwms_general.config
-        /etc/condor/config.d/01_gwms_collectors.config 
-        /etc/condor/config.d/02_gwms_schedds.config 
-        /etc/condor/config.d/03_gwms_local.config 
+        /etc/condor/config.d/01_gwms_collectors.config
+        /etc/condor/config.d/02_gwms_schedds.config
+        /etc/condor/config.d/03_gwms_local.config
         /etc/condor/config.d/11_gwms_secondary_collectors.config
-        /etc/condor/config.d/90_gwms_dns.config 
+        /etc/condor/config.d/90_gwms_dns.config
 	%RED%/etc/condor/condor_config.local%ENDCOLOR%
 
 If, like in the example above, the GlideinWMS configuration files are not the last ones in the list please verify that important configuration options have not been overridden by the other configuration files.
@@ -409,13 +409,13 @@ If, like in the example above, the GlideinWMS configuration files are not the la
 
 1. The glideinWMS configuration files in `/etc/condor/config.d` should be the last ones in the list. If not, please verify that important configuration options have not been overridden by the other configuration files.
 
-2. Verify the alll the expected HTCondor daemons are running: 
+2. Verify the alll the expected HTCondor daemons are running:
 
         :::console
-        [root@client ~] # condor_config_val -verbose DAEMON_LIST DAEMON_LIST: MASTER, COLLECTOR, NEGOTIATOR, SCHEDD, SHARED_PORT, COLLECTOR0 
-        COLLECTOR1 COLLECTOR2 COLLECTOR3 COLLECTOR4 COLLECTOR5 COLLECTOR6 COLLECTOR7 COLLECTOR8 COLLECTOR9 COLLECTOR10 , COLLECTOR11, COLLECTOR12, 
-        COLLECTOR13, COLLECTOR14, COLLECTOR15, COLLECTOR16, COLLECTOR17, COLLECTOR18, COLLECTOR19, COLLECTOR20, COLLECTOR21, COLLECTOR22, COLLECTOR23, 
-        COLLECTOR24, COLLECTOR25, COLLECTOR26, COLLECTOR27, COLLECTOR28, COLLECTOR29, COLLECTOR30, COLLECTOR31, COLLECTOR32, COLLECTOR33, COLLECTOR34, 
+        [root@client ~] # condor_config_val -verbose DAEMON_LIST DAEMON_LIST: MASTER, COLLECTOR, NEGOTIATOR, SCHEDD, SHARED_PORT, COLLECTOR0
+        COLLECTOR1 COLLECTOR2 COLLECTOR3 COLLECTOR4 COLLECTOR5 COLLECTOR6 COLLECTOR7 COLLECTOR8 COLLECTOR9 COLLECTOR10 , COLLECTOR11, COLLECTOR12,
+        COLLECTOR13, COLLECTOR14, COLLECTOR15, COLLECTOR16, COLLECTOR17, COLLECTOR18, COLLECTOR19, COLLECTOR20, COLLECTOR21, COLLECTOR22, COLLECTOR23,
+        COLLECTOR24, COLLECTOR25, COLLECTOR26, COLLECTOR27, COLLECTOR28, COLLECTOR29, COLLECTOR30, COLLECTOR31, COLLECTOR32, COLLECTOR33, COLLECTOR34,
         COLLECTOR35, COLLECTOR36, COLLECTOR37, COLLECTOR38, COLLECTOR39, COLLECTOR40
         Defined in '/etc/condor/config.d/11_gwms_secondary_collectors.config', line 193.
 
@@ -436,7 +436,7 @@ The Condor grid mapfile (`/etc/condor/certs/condor_mapfile`) is used for authent
 - %GREEN%Frontend proxy%ENDCOLOR%: The DN of the proxy that the frontend uses to communicate with the other glideinWMS services. Specified in the frontend.xml security element `proxy_DN` attribute:
 
         :::file
-        <security classad_proxy="/tmp/vo_proxy" proxy_DN="DN of vo_proxy" ....        
+        <security classad_proxy="/tmp/vo_proxy" proxy_DN="DN of vo_proxy" ....
 
 - %RED%Each pilot proxy%ENDCOLOR% The DN of __each__ proxy that the frontend forwards to the factory to use with the glideinWMS pilots.  This allows the !glideinWMs pilot jobs to communicate with the User Collector. Specified in the frontend.xml proxy `absfname` attribute (you need to specify the `DN` of each of those proxies:
 
@@ -458,7 +458,7 @@ GSI "%GREEN%DN of frontend proxy%ENDCOLOR%" frontend
 GSI "%RED%DN of pilot proxy%ENDCOLOR%$" pilot_proxy
 GSI "^\/DC\=org\/DC\=doegrids\/OU\=Services\/CN\=personal\-submit\-host2\.mydomain\.edu$" %RED%<example_of_format>%ENDCOLOR%
 GSI (.*) anonymous
-FS (.*) \1 
+FS (.*) \1
 ```
 
 ### Restart Condor
@@ -477,23 +477,23 @@ There are 2 types of (or purposes for) proxies required for the VO Frontend: 1 t
 ### Manual proxy renewal
 
 %GREEN%VO Frontend proxy%ENDCOLOR%
-The VO Frontend Proxy is used for communicating with the other glideinWMS services (Factory, User Collector and Schedd/Submit services). Create the proxy using the glidenWMS VO Frontend Host (or Service) cert and change ownership to the frontend user. 
+The VO Frontend Proxy is used for communicating with the other glideinWMS services (Factory, User Collector and Schedd/Submit services). Create the proxy using the glidenWMS VO Frontend Host (or Service) cert and change ownership to the frontend user.
 
     :::console
     [root@client ~] # voms-proxy-init-valid %RED%<hours_valid>%ENDCOLOR% \
-    -cert /etc/grid-security/hostcert.pem \ 
-    -key /etc/grid-security/hostkey.pem \ 
+    -cert /etc/grid-security/hostcert.pem \
+    -key /etc/grid-security/hostkey.pem \
     -out %GREEN%/tmp/vofe_proxy%ENDCOLOR%
     [root@client ~] # chown frontend %GREEN%/tmp/vofe_proxy%ENDCOLOR%
 
 %RED%Pilot proxy%ENDCOLOR%
-The pilot proxy is used on the glideinWMS pilot jobs submitted to the CEs. Create the proxy using the %RED%pilot certificate%ENDCOLOR% and change ownership to the frontend user. 
+The pilot proxy is used on the glideinWMS pilot jobs submitted to the CEs. Create the proxy using the %RED%pilot certificate%ENDCOLOR% and change ownership to the frontend user.
 
     :::console
-    [root@client ~] # voms-proxy-init -valid %RED%<hours_valid>%ENDCOLOR%\ 
-    -voms <vo> 
+    [root@client ~] # voms-proxy-init -valid %RED%<hours_valid>%ENDCOLOR%\
+    -voms <vo>
     -cert <pilot_cert> \
-    -key <pilot_key> \ 
+    -key <pilot_key> \
     -out %RED%/tmp/pilot_proxy%ENDCOLOR%
     [root@client ~] # chown frontend %RED%/tmp/pilot_proxy%ENDCOLOR%
 
@@ -518,13 +518,13 @@ Preparation for the %GREEN%VO Frontend proxy%ENDCOLOR%. You'll have to redo this
 2. Change ownership and permission of the certificate and key
 
         :::console
-        [root@client ~] # chown frontend: /var/lib/gwms-frontend/host**.pem 
+        [root@client ~] # chown frontend: /var/lib/gwms-frontend/host**.pem
         [root@client ~] # chmod 0600 /var/lib/gwms-frontend/host**.pem
 
 
 Preparation for the %RED% pilot proxy%ENDCOLOR%. You'll have to redo this for each new or renewed pilot cert.
 
-1. Create the proxy using the pilot certificate/key (as the user/submitter) 
+1. Create the proxy using the pilot certificate/key (as the user/submitter)
 
         :::console
         [root@client ~] # grid-proxy-init -valid 8800:0 -out /tmp/tmp_proxy
@@ -535,13 +535,13 @@ Preparation for the %RED% pilot proxy%ENDCOLOR%. You'll have to redo this for ea
         [root@client ~] # cp /tmp/tmp_proxy /var/lib/gwms-frontend/vofe_base_gi_delegated_proxy
         [root@client ~] # chown frontend: /var/lib/gwms-frontend/vofe_base_gi_delegated_proxy
         [root@client ~] # chmod 0600 /var/lib/gwms-frontend/vofe_base_gi_delegated_proxy
-        [root@client ~] # rm /tmp/tmp_proxy 
+        [root@client ~] # rm /tmp/tmp_proxy
 
 Configure the script for the %GREEN%VO Frontend proxy%ENDCOLOR%
 
 1. Download the [attached script](../other/make-proxy.sh) (the latest one is [Here on Github](https://raw.github.com/DHTC-Tools/OSG-Connect/master/gwms-frontend/make-proxy.sh)) and save it as `/var/lib/gwms-frontend/make-frontend-proxy.sh`, make sure that it is executable.
 
-2. Edit the VARIABLES section to look something like (replace your email, host name and the paths that are different in your setup - the comments in the script will help): 
+2. Edit the VARIABLES section to look something like (replace your email, host name and the paths that are different in your setup - the comments in the script will help):
 
         :::file
         SETUP_FILE=""
@@ -558,7 +558,7 @@ Configure the script for the %RED%pilot proxy%ENDCOLOR%:
 
 1.  Download the [attached script](../other/make-proxy.sh) (the latest one is [Here on Github](https://raw.github.com/DHTC-Tools/OSG-Connect/master/gwms-frontend/make-proxy.sh)) and save it as `/var/lib/gwms-frontend/make-pilot-proxy.sh`, make sure that it is executable.
 
-2.  Edit the VARIABLES section to look something like (replace your email, host name and the paths that are different in your setup - the comments in the script will help): 
+2.  Edit the VARIABLES section to look something like (replace your email, host name and the paths that are different in your setup - the comments in the script will help):
 
         :::file
         SETUP_FILE=""
@@ -573,12 +573,12 @@ Configure the script for the %RED%pilot proxy%ENDCOLOR%:
 Before adding the scripts to the crontab I'd recommend to test them manually once to make sure that there are no errors. As user `frontend` run the scripts (you can also use **`sh -x`** to debug them):
 
     :::console
-    /var/lib/gwms-frontend/make-frontend-proxy.sh --no-voms-proxy /var/lib/gwms-frontend/make-pilot-proxy.sh 
+    /var/lib/gwms-frontend/make-frontend-proxy.sh --no-voms-proxy /var/lib/gwms-frontend/make-pilot-proxy.sh
 
-Add the scripts to the crontab of the user `frontend` with `crontab -e`: 
+Add the scripts to the crontab of the user `frontend` with `crontab -e`:
 
     :::file
-    10 * * * * /var/lib/gwms-frontend/make-frontend-proxy.sh --no-voms-proxy 
+    10 * * * * /var/lib/gwms-frontend/make-frontend-proxy.sh --no-voms-proxy
     10 * * * * /var/lib/gwms-frontend/make-pilot-proxy.sh
 
 An additional script like [make-proxy-control.sh](../other/make-proxy-control.sh) (the latest one is [Here on Github](https://raw.github.com/DHTC-Tools/OSG-Connect/master/gwms-frontend/make-proxy-control.sh)) can be used for an independent verification of the proxies. If you like, download it, fix the variables and add it to the crontab like the other two.
@@ -600,7 +600,7 @@ Reconfigure and verify installation
 After this initial reconfiguring/upgrading, you can start the frontend:
 
      %RED%# For RHEL 6, CentOS 6, and SL6%ENDCOLOR%
-     [root@client ~] # service gwms-frontend start 
+     [root@client ~] # service gwms-frontend start
      %RED%# For RHEL 7, CentOS 7, and SL7%ENDCOLOR%
      [root@client ~] # systemctl start gwms-frontend
 
@@ -653,7 +653,7 @@ To perform configuration changes without impacting production the recommended wa
 1. Create a [group](http://glideinwms.fnal.gov/doc.prd/frontend/configuration.html#management) named itb.
 
 2. Set the group's `start_expr` so that the group's glideins will only match user jobs with `+is_itb=True`:
-  
+
         :::file
         <match match_expr="True" start_expr="(is_itb)">
 
@@ -670,13 +670,13 @@ To perform configuration changes without impacting production the recommended wa
                   my_identity="username@gfactory-1.t2.ucsd.edu" \
                   node="glidein-itb.grid.iu.edu"/>
 
-5. Set the job `query_expr` so that only ITB jobs appear in `condor_q`: 
+5. Set the job `query_expr` so that only ITB jobs appear in `condor_q`:
 
         :::file
         <job query_expr="(!isUndefined(is_itb) && is_itb)">
 
 6. Reconfigure the Frontend:
-  
+
         :::file
         /etc/init.d/gwms-frontend reconfig
 
@@ -691,11 +691,11 @@ The scripts updating your CA and CRLs plus three frontend services need to be ru
 
         :::console
         %RED%# For RHEL 6, CentOS 6, and SL6, or OSG 3 _older_ than 3.1.15%ENDCOLOR%
-        [root@client ~]$ /usr/sbin/fetch-crl   # This fetches the CRLs 
+        [root@client ~]$ /usr/sbin/fetch-crl   # This fetches the CRLs
         [root@client ~]$ /sbin/service fetch-crl-boot start
         [root@client ~]$ /sbin/service fetch-crl-cron start
         %RED% # For RHEL 7, CentOS 7, and SL7 %ENDCOLOR%
-        [root@client ~]$ /usr/sbin/fetch-crl   # This fetches the CRLs 
+        [root@client ~]$ /usr/sbin/fetch-crl   # This fetches the CRLs
         [root@client ~]$ systemctl start fetch-crl-boot
         [root@client ~]$ systemctl start fetch-crl-cron
 
@@ -704,28 +704,28 @@ The scripts updating your CA and CRLs plus three frontend services need to be ru
         :::console
         %RED%# For RHEL 6, CentOS 6, and SL6%ENDCOLOR%
         [root@client ~] # service condor start
-        [root@client ~] # service httpd start 
+        [root@client ~] # service httpd start
         [root@client ~] # service gwms-frontend start
         %RED%# For RHEL 7, CentOS 7, and SL7%ENDCOLOR%
-        [root@client ~]	# systemctl start condor 
+        [root@client ~]	# systemctl start condor
         [root@client ~] # systemctl start gwms-frontend
 
 !!! note
     Once you successfully start using the frontend service, each time you change the configuration or want to upgrade, you run the following command
-          
+
         :::console
         %RED%# For RHEL 6, CentOS 6, and SL6%ENDCOLOR%
-        [root@client ~] # service gwms-frontend reconfig 
-        %RED%# And if you change also some code%ENDCOLOR% 
+        [root@client ~] # service gwms-frontend reconfig
+        %RED%# And if you change also some code%ENDCOLOR%
         [root@client ~] # service gwms-frontend upgrade
- 
+
         %RED%# But the situation is a bit more complicated in RHEL 7, CentOS 7, and SL7 due to systemd restrictions%ENDCOLOR%
         %GREEN%# For reconfig:%ENDCOLOR%
         %RED%A. when the frontend is running%ENDCOLOR%
         %RED%A.1 without any additional options%ENDCOLOR%
-        [root@client ~] # /usr/sbin/gwms-frontend reconfig%ENDCOLOR% 
+        [root@client ~] # /usr/sbin/gwms-frontend reconfig%ENDCOLOR%
         or
-        [root@client ~] # systemctl reload gwms-frontend 
+        [root@client ~] # systemctl reload gwms-frontend
 
         %RED%A.2 if you want to give additional options %ENDCOLOR%
         systemctl stop gwms-frontend
@@ -737,11 +737,11 @@ The scripts updating your CA and CRLs plus three frontend services need to be ru
 
         %GREEN%# For upgrade:%ENDCOLOR%
         %RED%A. when the frontend is running %ENDCOLOR%
-        systemctl stop gwms-frontend 
+        systemctl stop gwms-frontend
         /usr/sbin/gwms-frontend upgrade ("and your options if any")
         systemctl start gwms-frontend
 
-        %RED%B. when the frontend is NOT running %ENDCOLOR% 
+        %RED%B. when the frontend is NOT running %ENDCOLOR%
         /usr/sbin/gwms-frontend upgrade ("and your options if any")
 
 To stop the frontend:
@@ -750,7 +750,7 @@ To stop the frontend:
     %RED%# For RHEL 6, CentOS 6, and SL6%ENDCOLOR%
     [root@client ~] # service gwms-frontend stop
     %RED%# For RHEL 7, CentOS 7, and SL7%ENDCOLOR%
-    [root@client ~] # systemctl stop gwms-frontend 
+    [root@client ~] # systemctl stop gwms-frontend
 
 And you can stop also the other services if you are not using them independently form the frontend.
 
@@ -762,22 +762,22 @@ The complete validation of the frontend is the submission of actual jobs. Howeve
 1. Verify all Condor daemons are started.
 
         :::file
-        [user@client ~]$ condor_config_val -verbose DAEMON_LIST 
-        DAEMON_LIST: MASTER,  COLLECTOR, NEGOTIATOR,  SCHEDD, SHARED_PORT, SCHEDDJOBS2 COLLECTOR0 COLLECTOR1 COLLECTOR2 
-        COLLECTOR3 COLLECTOR4 COLLECTOR5 COLLECTOR6 COLLECTOR7 COLLECTOR8 COLLECTOR9 COLLECTOR10 , COLLECTOR11, 
-        COLLECTOR12, COLLECTOR13, COLLECTOR14, COLLECTOR15, COLLECTOR16, COLLECTOR17, COLLECTOR18, COLLECTOR19, COLLECTOR20, 
-        COLLECTOR21, COLLECTOR22, COLLECTOR23, COLLECTOR24, COLLECTOR25, COLLECTOR26, COLLECTOR27, COLLECTOR28, COLLECTOR29, 
-        COLLECTOR30, COLLECTOR31, COLLECTOR32, COLLECTOR33, COLLECTOR34, COLLECTOR35, COLLECTOR36, COLLECTOR37, COLLECTOR38, 
+        [user@client ~]$ condor_config_val -verbose DAEMON_LIST
+        DAEMON_LIST: MASTER,  COLLECTOR, NEGOTIATOR,  SCHEDD, SHARED_PORT, SCHEDDJOBS2 COLLECTOR0 COLLECTOR1 COLLECTOR2
+        COLLECTOR3 COLLECTOR4 COLLECTOR5 COLLECTOR6 COLLECTOR7 COLLECTOR8 COLLECTOR9 COLLECTOR10 , COLLECTOR11,
+        COLLECTOR12, COLLECTOR13, COLLECTOR14, COLLECTOR15, COLLECTOR16, COLLECTOR17, COLLECTOR18, COLLECTOR19, COLLECTOR20,
+        COLLECTOR21, COLLECTOR22, COLLECTOR23, COLLECTOR24, COLLECTOR25, COLLECTOR26, COLLECTOR27, COLLECTOR28, COLLECTOR29,
+        COLLECTOR30, COLLECTOR31, COLLECTOR32, COLLECTOR33, COLLECTOR34, COLLECTOR35, COLLECTOR36, COLLECTOR37, COLLECTOR38,
         COLLECTOR39, COLLECTOR40
         Defined in '/etc/condor/config.d/11_gwms_secondary_collectors.config', line 193.
- 
+
        If you don't see all the collectors and the two schedd, then the configuration must be corrected. There should be no startd daemons listed
 
 2. Verify all VO Frontend Condor services are communicating.
 
         :::file
         [user@client ~]$ condor_status -any
-        MyType               TargetType           Name                          
+        MyType               TargetType           Name
         glideresource        None                 MM_fermicloud026@gfactory_inst
         Scheduler            None                 fermicloud020.fnal.gov
         DaemonMaster         None                 fermicloud020.fnal.gov
@@ -855,7 +855,7 @@ Here a short list of files to check when you change the certificates. Note that 
 | VO Frontend proxy (from host certificate) |                            /tmp/vofe\_proxy (3)                           |
 |                Pilot proxy                |                            /tmp/vofe\_proxy (3)                           |
 
-1. If using HTCondor RPM installation, e.g. the one coming from OSG. If you have separate/multiple HTCondor hosts (schedds, collectors, negotiators, ..) you may have to check this file on all of them to make sure that the HTCondor authentication works correctly. 
+1. If using HTCondor RPM installation, e.g. the one coming from OSG. If you have separate/multiple HTCondor hosts (schedds, collectors, negotiators, ..) you may have to check this file on all of them to make sure that the HTCondor authentication works correctly.
 
 2. Used to create the VO Frontend proxy if following the [instructions above](#proxy-configuration)
 
@@ -975,6 +975,3 @@ Documents about the Glidein-WMS system and the VO frontend:
 -   <http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/>
 -   <http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/doc.prd/manual/>
 -   [How to setup a Submit host flocking to the VO Frontend](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/GlideinWMSCampusGrid)
-
-
-

--- a/docs/security/install-gums.md
+++ b/docs/security/install-gums.md
@@ -22,7 +22,7 @@ As with all OSG software installations, there are some one-time (per host) steps
 - Ensure the host has [a supported operating system](../release/supported_platforms)
 - Obtain root access to the host
 - Prepare the [required Yum repositories](../common/yum)
-- Install [CA certificates](https://twiki.grid.iu.edu/bin/view/Documentation/Release3/InstallCertAuth)
+- Install [CA certificates](../common/ca)
 
 Installing GUMS
 ---------------
@@ -199,7 +199,7 @@ The GUMS service is actually a web application running within the Tomcat web app
 
     | Software          | Service name                          | Notes                                                                                  |
     |:------------------|:--------------------------------------|:---------------------------------------------------------------------------------------|
-    | Fetch CRL         | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallCertAuth#Start_Stop_fetch_crl_A_quick_gui) for more info |
+    | Fetch CRL         | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](../common/ca/#startstop-fetch-crl-a-quick-guide) for more info |
     | MySQL             | `mysqld`                              |                                                                                        |
     | Tomcat            | `tomcat6`                             |                                                                                        |
 
@@ -207,7 +207,7 @@ The GUMS service is actually a web application running within the Tomcat web app
 
     | Software          | Service name                          | Notes                                                                                  |
     |:------------------|:--------------------------------------|:---------------------------------------------------------------------------------------|
-    | Fetch CRL         | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallCertAuth#Start_Stop_fetch_crl_A_quick_gui) for more info |
+    | Fetch CRL         | `fetch-crl-boot` and `fetch-crl-cron` | See [CA documentation](../common/ca/#startstop-fetch-crl-a-quick-guide) for more info |
     | MariaDB           | `mariadb`                             |                                                                                        |
     | Tomcat            | `tomcat`                              |                                                                                        |
 

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -36,7 +36,7 @@ To install the LCMAPS VOMS plugin, make sure that your host is up to date before
 Configuring the LCMAPS VOMS Plugin
 ----------------------------------
 
-The following section describes the steps required to configure the LCMAPS VOMS plugin for authentication. If you are using OSG 3.3 packages, there are software-specific instructions that must be followed for [HTCondor-CE](../compute-element/install-htcondor-ce), [GridFTP](../storage/gridftp), and [XRootD](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallXrootd). To check if you are running OSG 3.3, run the following command:
+The following section describes the steps required to configure the LCMAPS VOMS plugin for authentication. If you are using OSG 3.3 packages, there are software-specific instructions that must be followed for [HTCondor-CE](../compute-element/install-htcondor-ce), [GridFTP](../data/gridftp), and [XRootD](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/InstallXrootd). To check if you are running OSG 3.3, run the following command:
 
 ``` console
 [root@server]# rpm -q --queryformat="%{VERSION}\n" osg-release

--- a/docs/worker-node/install-cvmfs.md
+++ b/docs/worker-node/install-cvmfs.md
@@ -106,7 +106,7 @@ set of always-known repositories.
 
 Set up a list of CVMFS HTTP proxies to retrieve from in
 `CVMFS_HTTP_PROXY`. If you do not have any squid at your site follow
-the instructions to [install squid from OSG](InstallFrontierSquid).
+the instructions to [install squid from OSG](../data/frontier-squid).
 Vertical bars separating proxies means to load balance between them
 and try them all before continuing. A semicolon between proxies means
 to try that one only after the previous ones have failed. A special


### PR DESCRIPTION
Ran linkchecker against the webpage generated from the docs repo and fixed 404s it reported. Some of the links were changed to point back to the twiki.