### PR TITLE
Fix deprecated theme_dir specification

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,9 @@
 site_name: OSG Documentation
 site_url: https://opensciencegrid.github.io/docs
 repo_url: https://github.com/opensciencegrid/docs
-theme: readthedocs
-theme_dir: osgthedocs
+theme:
+  name: readthedocs
+  custom_dir: osgthedocs
 
 extra_css:
   - css/extra.css

--- a/osgthedocs/404.html
+++ b/osgthedocs/404.html
@@ -1,0 +1,7 @@
+{% block content %}
+
+  <h1 id="404-page-not-found">404</h1>
+
+  <p><strong>Page not found</strong></p>
+
+{% endblock %}


### PR DESCRIPTION
Deprecated as of [0.17.0](https://github.com/mkdocs/mkdocs/blob/master/docs/about/release-notes.md)