### PR TITLE
Scrub a few remaining GRAM references.

### DIFF
--- a/docs/compute-element/htcondor-ce-overview.md
+++ b/docs/compute-element/htcondor-ce-overview.md
@@ -1,16 +1,8 @@
 HTCondor-CE Overview
 ====================
 
-
-About this Document
--------------------
-
-This document serves as an introduction to HTCondor-CE, how it works, and how it differs from a GRAM CE.
-
-Document Requirements
----------------------
-
-Before continuing with this document, make sure that you are familiar with the following concepts:
+This document serves as an introduction to HTCondor-CE and how it works.
+Before continuing with the overview, make sure that you are familiar with the following concepts:
 
 -   An OSG site plan
     -   What is a batch system and which one will you use ([HTCondor](http://htcondor.org/), PBS, LSF, SGE, or SLURM)?
@@ -20,7 +12,7 @@ Before continuing with this document, make sure that you are familiar with the f
 What is a Compute Element?
 --------------------------
 
-An OSG Compute Element (CE) is the entry point for the OSG to your local resources: a layer of software that you install on a machine that can submit jobs into your local batch system. At the heart of the CE is the *job gateway* software, which is responsible for handling incoming jobs, authorizing them, and delegating them to your batch system for execution. Historically, the OSG only had one option for a job gateway solution, Globus Toolkit’s GRAM-based gatekeeper, but now offers the HTCondor-CE as an alternative.
+An OSG Compute Element (CE) is the entry point for the OSG to your local resources: a layer of software that you install on a machine that can submit jobs into your local batch system. At the heart of the CE is the *job gateway* software, which is responsible for handling incoming jobs, authorizing them, and delegating them to your batch system for execution.
 
 Today in OSG, most jobs that arrive at a CE (called *grid jobs*) are **not** end-user jobs, but rather pilot jobs submitted from factories. Successful pilot jobs create and make available an environment for actual end-user jobs to match and ultimately run within the pilot job container. Eventually pilot jobs remove themselves, typically after a period of inactivity.
 
@@ -29,11 +21,7 @@ What is HTCondor-CE?
 
 HTCondor-CE is a special configuration of the HTCondor software designed to be a job gateway solution for the OSG. It is configured to use the [JobRouter daemon](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html) to delegate jobs by transforming and submitting them to the site’s batch system.
 
-### How is HTCondor-CE different from a GRAM CE?
-
-The biggest difference you will see between an HTCondor-CE and a GRAM CE is in the way that jobs are submitted to your batch system; HTCondor-CE uses the built-in JobRouter daemon whereas GRAM CE uses jobmanager scripts written in Perl. Customizing your site’s CE now requires editing configuration files instead of editing jobmanager scripts.
-
-Listed below are some other benefits to switching to HTCondor-CE:
+Other benefits of running the HTCondor-CE:
 
 -   **Scalability:** HTCondor-CE is capable of supporting job workloads of large sites (see [scale testing results](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/HTCondorCEScaleTests))
 -   **Debugging tools:** HTCondor-CE offers [many tools to help troubleshoot](troubleshoot-htcondor-ce) issues with jobs
@@ -86,7 +74,9 @@ How the CE is Customized
 
 Aside from the [basic configuration](install-htcondor-ce#configuring-htcondor-ce) required in the CE installation, there are two main ways to customize your CE (if you decide any customization is required at all):
 
--   **Deciding which VOs are allowed to run at your site:** The method of limiting the VOs that are allowed to run on your site has not changed between GRAM and HTCondor-CE’s: select an authorization system, GUMS or edg-mkgridmap, and configure it accordingly.
+-   **Deciding which VOs are allowed to run at your site:** The recommended method of authorizing VOs at your site is
+    based on the [LCMAPS framework](../security/lcmaps-voms-authentication); we plan to support the prior mechanisms,
+    [GUMS](../security/install-gums) and [edg-mkgridmap](../security/edg-mkgridmap) until May 2018.
 -   **How to filter and transform the grid jobs to be run on your batch system:** Filtering and transforming grid jobs (i.e., setting site-specific attributes or resource limits), requires configuration of your site’s job routes. For examples of common job routes, consult the [JobRouter recipes](job-router-recipes) page.
 
 !!! note
@@ -99,14 +89,14 @@ In the OSG, security depends on a PKI infrastructure involving Certificate Autho
 
 Due to the OSG's distributed nature, a user's job may end up at any number of sites, potentially needing to re-authenticate at multiple points. Instead of sending the user's certificate with the job for this re-authentication, trust can be delegated to a proxy that is generated from the user certificate, which is then attached to the job and expires after some set time for added security.
 
-In its default configuration, HTCondor-CE uses GSI-based authentication and authorization (the same as Globus GRAM) to verify the certificate chain, which will work with existing GUMS servers or grid mapfiles. Additionally, it can be reconfigured to provide alternate authentication mechanisms such as Kerberos, SSL, shared secret, or even IP-based authentication. More information about authorization methods can be found [here](http://research.cs.wisc.edu/htcondor/manual/v8.6/3_8Security.html#SECTION00483000000000000000).
+In its default configuration, HTCondor-CE uses GSI-based authentication and authorization to verify the certificate chain, which will work with existing GUMS servers or grid mapfiles. Additionally, it can be reconfigured to provide alternate authentication mechanisms such as Kerberos, SSL, shared secret, or even IP-based authentication. More information about authorization methods can be found [here](http://research.cs.wisc.edu/htcondor/manual/v8.6/3_8Security.html#SECTION00483000000000000000).
 
 Next steps
 ----------
 
-If you're transitioning from a GRAM CE to HTCondor-CE, the process is the same as if you were setting up a completely new CE, whether you're installing it on a new machine or alongside your GRAM CE.
+Once the basic installation is done, additional activities include:
 
--   Setting up [job routes](job-router-recipes)
+-   Setting up [job routes](job-router-recipes) to customize incoming jobs:
 -   [Submitting](submit-htcondor-ce) jobs to HTCondor-CE
 -   [Troubleshooting](troubleshoot-htcondor-ce) HTCondor-CE
 -   Register the CE with OIM

--- a/docs/compute-element/htcondor-ce-overview.md
+++ b/docs/compute-element/htcondor-ce-overview.md
@@ -21,7 +21,7 @@ What is HTCondor-CE?
 
 HTCondor-CE is a special configuration of the HTCondor software designed to be a job gateway solution for the OSG. It is configured to use the [JobRouter daemon](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html) to delegate jobs by transforming and submitting them to the site’s batch system.
 
-Other benefits of running the HTCondor-CE:
+Benefits of running the HTCondor-CE:
 
 -   **Scalability:** HTCondor-CE is capable of supporting job workloads of large sites (see [scale testing results](https://twiki.opensciencegrid.org/bin/view/Documentation/Release3/HTCondorCEScaleTests))
 -   **Debugging tools:** HTCondor-CE offers [many tools to help troubleshoot](troubleshoot-htcondor-ce) issues with jobs
@@ -96,7 +96,7 @@ Next steps
 
 Once the basic installation is done, additional activities include:
 
--   Setting up [job routes](job-router-recipes) to customize incoming jobs:
+-   Setting up [job routes](job-router-recipes) to customize incoming jobs
 -   [Submitting](submit-htcondor-ce) jobs to HTCondor-CE
 -   [Troubleshooting](troubleshoot-htcondor-ce) HTCondor-CE
 -   Register the CE with OIM

--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -71,7 +71,7 @@ There are a few required configuration steps to connect HTCondor-CE with your ba
 
 ### Enabling HTCondor-CE
 
-If you are installing HTCondor-CE on a new host, the default configuration is correct and you can skip this step and continue onto [Configuring the batch system](#configuring-the-batch-system)! However, if you are updating a host that used a Globus GRAM job gateway (aka the Globus gatekeeper), you must disable GRAM and enable the HTCondor job gateway. Edit the gateway configuration file `/etc/osg/config.d/10-gateway.ini` so that it reads:
+If you are installing HTCondor-CE on a new host, the default configuration is correct and you can skip this step and continue onto [Configuring the batch system](#configuring-the-batch-system)! However, if you are updating a host that used a Globus GRAM job gateway ("Globus gatekeeper"), you must disable GRAM and enable the HTCondor job gateway. Edit the gateway configuration file `/etc/osg/config.d/10-gateway.ini` so that it reads:
 
 ```
 gram_gateway_enabled = False
@@ -233,7 +233,7 @@ Replacing `condorce.example.com` text with your public interface’s hostname an
 
 #### Limiting or disabling locally running jobs on the CE
 
-If you want to limit or disable jobs running locally on your CE, you will need to configure HTCondor-CE's local and scheduler universes. Local and scheduler universes are HTCondor-CE’s analogue to GRAM’s managed fork: they allow jobs to be run on the CE itself, mainly for remote troubleshooting. Pilot jobs will not run as local/scheduler universe jobs so leaving them enabled does NOT turn your CE into another worker node.
+If you want to limit or disable jobs running locally on your CE, you will need to configure HTCondor-CE's local and scheduler universes. Local and scheduler universes allow jobs to be run on the CE itself, mainly for remote troubleshooting. Pilot jobs will not run as local/scheduler universe jobs so leaving them enabled does NOT turn your CE into another worker node.
 
 The two universes are effectively the same (scheduler universe launches a starter process for each job), so we will be configuring them in unison.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,17 +77,17 @@ If necessary, provision all OSG hosts that are in your site plan and that do not
 
 ### Installing and Configuring Other Services ###
 
-All of these node types and their services are optional, although OSG requires a HTTP caching service if you have
+All of these node types and their services are optional, although OSG requires an HTTP caching service if you have
 installed [CVMFS](worker-node/install-cvmfs) on your worker nodes.
 
--   [Install Frontier Squid](data/frontier-squid), a HTTP caching proxy service.
+-   [Install Frontier Squid](data/frontier-squid), an HTTP caching proxy service.
 -   Storage element:
     -   Existing POSIX-based systems (such as NFS, Lustre, or GPFS):
         -   [Install standalone OSG GridFTP](data/gridftp): GridFTP server
         -   (optional) [Install load-balanced OSG GridFTP](data/load-balanced-gridftp): when a single GridFTP server isn't enough
     -   Hadoop Distributed File System (HDFS):
         -   [Hadoop Overview](data/hadoop-overview): HDFS information, planning, and guides
-    -   XRootD-based storage:
+    -   XRootD:
         -   [XRootd Overview](data/xrootd-overview): XRootD information, planning, and guides
         -   [Install Xrootd Server](data/install-xrootd): XRootD redirector installation
 -   RSV monitoring to monitor and report to OSG on the health of your site
@@ -110,8 +110,8 @@ To begin running [GlideinWMS](http://www.uscms.org/SoftwareComputing/Grid/WMS/gl
 
 -   The fully qualified hostname of the CE
 -   Resource/WLCG name
--   OS major version of your worker nodes — EL 6, EL 7, or a mix of both?
--   Do you accept multicore jobs?
+-   Supported OS version of your worker nodes (e.g., EL6, EL7, or both)
+-   Support for multicore jobs
 -   Maximum job walltime
 -   Maximum job memory usage
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,19 @@
 OSG Site Administrator Documentation
 ====================================
 
-Welcome to the home page of the Open Science Grid (OSG) Site Administrator documentation! If you are not a site adminstrator...
+Welcome to the home of the Open Science Grid (OSG) Site Administrator documentation!  This documentation aims to
+provide OSG site admins with the necessary information to install, configure, and operate site services.
 
-- If you are a researcher interested in using OSG resources, you can find user documentation [here](https://support.opensciencegrid.org/support/home). 
-- If you'd like to learn more about the OSG and our mission, visit our website [here](https://www.opensciencegrid.org/).
+If you are not a site adminstrator:
 
-This document outlines the overall installation process for an OSG site and provides many links into detailed installation, configuration, troubleshooting, and similar pages. If you do not see software-related technical documentation listed here, try the search bar to the left or contacting us at [help@opensciencegrid.org](mailto:help@opensciencegrid.org).
+- If you are a **researcher** interested in using OSG resources, you may want to view our
+  [user documentation](https://support.opensciencegrid.org/support/home).
+- If you'd like to learn more about the OSG and our mission, visit the OSG consortium's [homepage](https://www.opensciencegrid.org/).
+
+This document outlines the overall installation process for an OSG site and provides many links into detailed
+installation, configuration, troubleshooting, and similar pages. If you do not see software-related technical
+documentation listed here, try the search bar to the left or contacting us at
+[help@opensciencegrid.org](mailto:help@opensciencegrid.org).
 
 Plan the Site
 -------------
@@ -34,7 +41,6 @@ If necessary, provision all OSG hosts that are in your site plan and that do not
     For sites with more than a handful of worker nodes, it is recommended to use some sort of configuration management tool to install, configure, and maintain your site. While beyond the scope of OSG’s documentation to explain how to select and use such a system, some popular configuration management tools are [Puppet](http://puppetlabs.com), [Chef](https://www.chef.io), [Ansible](https://www.ansible.com), and [CFEngine](http://cfengine.com).
 
 ### General Installation Instructions ###
-
 
 -   [Security information for OSG signed RPMs](release/signing)
 -   [Using Yum and RPM](release/yum-basics)
@@ -69,33 +75,31 @@ If necessary, provision all OSG hosts that are in your site plan and that do not
     -   [Submitting jobs to HTCondor-CE](compute-element/submit-htcondor-ce)
 -   [`osg-configure` Reference](other/configuration-with-osg-configure)
 
-### Installing and Configuring Other Nodes ###
+### Installing and Configuring Other Services ###
 
-All of these node types and their services are optional, although OSG requires the Frontier Squid caching service if you have installed [CVMFS](worker-node/install-cvmfs) on your worker nodes.
+All of these node types and their services are optional, although OSG requires a HTTP caching service if you have
+installed [CVMFS](worker-node/install-cvmfs) on your worker nodes.
 
--   [Install Frontier Squid, the HTTP caching proxy service](data/frontier-squid)
+-   [Install Frontier Squid](data/frontier-squid), a HTTP caching proxy service.
+-   Storage element:
+    -   Existing POSIX-based systems (such as NFS, Lustre, or GPFS):
+        -   [Install standalone OSG GridFTP](data/gridftp): GridFTP server
+        -   (optional) [Install load-balanced OSG GridFTP](data/load-balanced-gridftp): when a single GridFTP server isn't enough
+    -   Hadoop Distributed File System (HDFS):
+        -   [Hadoop Overview](data/hadoop-overview): HDFS information, planning, and guides
+    -   XRootD-based storage:
+        -   [XRootd Overview](data/xrootd-overview): XRootD information, planning, and guides
+        -   [Install Xrootd Server](data/install-xrootd): XRootD redirector installation
 -   RSV monitoring to monitor and report to OSG on the health of your site
     -   [Install RSV](monitoring/install-rsv)
 -   [Install the GlideinWMS VO Frontend](other/install-gwms-frontend) if your want your users’ jobs to run on the OSG
-    -   [Install the RSV GlideinWMS Tester](monitoring/install-rsv-gwms-tester) if you want to test your front-end's ability to submit jobs to sites in the OSG
--   Storage element (pick one):
-    -   GridFTP
-        -   [Install standalone OSG GridFTP](data/gridftp): GridFTP server
-        -   (optional) [Install load-balanced OSG GridFTP](data/load-balanced-gridftp): when a single GridFTP server isn't enough
-    -   BeStMan
-        -   [Install Bestman on POSIX](data/bestman-install): BeStMan2 SRM server + GridFTP server
-        -   [Install Bestman on Hadoop](data/install-hadoop-2-0-0): BeStMan2 SRM and GridFTP servers on the Hadoop Distributed File System
-    -   Hadoop Distributed File System (HDFS)
-        -   [Hadoop Overview](data/hadoop-overview): HDFS information, planning, and guides
-    -   XRootD
-        -   [XRootd Overview](data/xrootd-overview): XRootD information, planning, and guides
-        -   [Install Xrootd Server](data/install-xrootd): XRootD redirector installation
-        -   [Install BeStMan-Gateway XRootD](data/install-bestman-xrootd): BeStMan2 SRM server + GridFTP server + XRootD fuse
+    -   [Install the RSV GlideinWMS Tester](monitoring/install-rsv-gwms-tester) if you want to test your front-end's
+        ability to submit jobs to sites in the OSG
 
 Test OSG Software
 -----------------
 
-At very least, it is vital to test *manual* submission of jobs from inside and outside of your site through your CE to your batch system. If this process does not work manually, it will probably not work for the glideinWMS pilot factory either.
+It is useful to test *manual* submission of jobs from inside and outside of your site through your CE to your batch system. If this process does not work manually, it will probably not work for the glideinWMS pilot factory either.
 
 -   [Test job submission into an HTCondor-CE](compute-element/submit-htcondor-ce)
 
@@ -104,7 +108,6 @@ Start GlideinWMS Pilot Submissions
 
 To begin running [GlideinWMS](http://www.uscms.org/SoftwareComputing/Grid/WMS/glideinWMS/) pilot jobs at your site, e-mail <osg-gfactory-support@physics.ucsd.edu> and tell them that you want to start accepting Glideins. Please provide them with the following information:
 
--   The type of CE (HTCondor-CE or the now-unsupported GRAM-CE)
 -   The fully qualified hostname of the CE
 -   Resource/WLCG name
 -   OS major version of your worker nodes — EL 6, EL 7, or a mix of both?


### PR DESCRIPTION
Given that GRAM is pretty far in the rearview mirror, this commit starts to remove references to GRAM.  I left only one remaining, which refers to a specific upgrade path.