### PR TITLE
Scrub extra references to bestman2.

### DIFF
--- a/docs/data/hadoop-overview.md
+++ b/docs/data/hadoop-overview.md
@@ -61,7 +61,7 @@ For a large installation, make the following changes: 1 Run more GridFTP servers
 Hadoop Security
 ---------------
 
-HDFS has unix-like user/group authorization, but no strict authentication. HDFS should only be exposed to a secure internal network which only non-malicious users are able to access. For users with access to the local cluster, it is not difficult at all to bypass authentication.
+HDFS has Unix-like user/group authorization, but no strict authentication. **HDFS should only be exposed to a secure internal network which only non-malicious users are able to access**. For users with access to the local cluster, it is not difficult to bypass authentication.
 
 [The default ports are listed here](http://www.cloudera.com/blog/2009/08/14/hadoop-default-ports-quick-reference/).
 
@@ -75,6 +75,6 @@ There are some ways to improve security of your cluster:
 
 There are three options to export your data outside your cluster:
 
--   Globus GridFTP / SRM. This is covered in these web pages.
--   Xrootd. Documentation is nascent.
--   Apache HTTP (authenticated via HTTPS). This is in use at Caltech, but there isn't any documentation available.
+-   Globus GridFTP.
+-   Xrootd.
+-   HTTP and HTTPS.  OSG utilizes the HTTP(S) protocol implementation built into the XRootD server.

--- a/docs/data/xrootd-overview.md
+++ b/docs/data/xrootd-overview.md
@@ -14,7 +14,6 @@ Installation
 ------------
 
 -   [Install Xrootd Server](install-xrootd): This page explains how to install an XRootD redirector and data nodes
--   [Install Bestman Gateway Xrootd](install-bestman-xrootd): Installing a SRM frontend with GridFTP for XRootD redirector (**Deprecated**).
 
 Operations
 ----------


### PR DESCRIPTION
This commit removes a few unnecessary references to bestman2; I've left all the documentation itself, but just made the HDFS and Xrootd docs a bit less bestman2-centric.

Additionally, this includes a mild cleanup of the Hadoop docs.  Honestly, they are still fairly low-quality - but can be further improved over a series of updates.