### PR TITLE
Rationalize the introduction to the WN installs.

### DIFF
--- a/docs/worker-node/install-wn-oasis.md
+++ b/docs/worker-node/install-wn-oasis.md
@@ -1,17 +1,16 @@
-Configuring a Site to Use the Worker Node Client Software From OASIS
-====================================================================
+Installing the Worker Node Client via OASIS
+===========================================
 
+The **OSG Worker Node Client** is a collection of software components that is expected to be added to every worker node
+that can run OSG jobs. It provides a common environment and a minimal set of common tools that all OSG jobs can expect
+to use. Contents of the worker node client can be found [here](install-wn.md#worker-node-contents).
 
-About This Guide
-----------------
+!!! note
+    It is possible to install the Worker Node Client software in a variety of ways, depending on your local site:
 
-The *OSG Worker Node Client* is a collection of software components that is expected to be added to every worker node that can run OSG jobs. It provides a common environment and a minimal set of common tools that all OSG jobs can expect to use.
-
-It is possible to install the Worker Node Client software in a variety of ways, depending on what works best for distributing and managing software at your site:
-
--   Use the Worker Node Client software from OASIS (this guide) - useful when [CVMFS](install-cvmfs) is already mounted on your worker nodes
--   [Install using RPMs and Yum](install-wn.md) - useful when managing your worker nodes with a tool (e.g., Puppet, Chef) that can automate RPM installs
--   [Install using a tarball](install-wn-tarball.md) - useful when installing onto a shared filesystem for distribution to worker nodes
+    -   Use from OASIS (this guide) - useful when [CVMFS](install-cvmfs) is already mounted on your worker nodes
+    -   [Install using a tarball](install-wn-tarball.md) - useful when installing onto a shared filesystem for distribution to worker nodes
+    -   [Install using RPMs and Yum](install-wn.md) - useful when managing your worker nodes with a tool (e.g., Puppet, Chef) that can automate RPM installs
 
 This document is intended to guide system administrators through the process of configuring a site to make the Worker Node Client software available from OASIS.
 
@@ -21,15 +20,13 @@ Before Starting
 As with all OSG software installations, there are some one-time (per host) steps to prepare in advance:
 
 -   Ensure the host has [a supported operating system](../release/supported_platforms.md)
+-   On every worker node, [install and configure CVMFS](install-cvmfs.md)
 
-Also note that, once configured to use OASIS, each use of Worker Node Client software will cause that software and its associated files to be downloaded from a CVMFS server or your local cache thereof. This may result in extra network activity, especially if Worker Node Client tools are used heavily.
+Once configured to use OASIS, grid jobs will download the worker-node software on demand (into the local disk cache).
+This may result in extra network activity, especially on first use of the client tools.
 
-Configuring Your Site to Use the Worker Node Client From OASIS
---------------------------------------------------------------
-
-Below are the one-time steps that you must perform to configure your site to use the Worker Node Client software from OASIS.
-
-On every worker node, [install and configure CVMFS](install-cvmfs.md)
+Configure the CE
+----------------
 
 Determine the OASIS path to the Worker Node Client software for your worker nodes:
 
@@ -41,14 +38,15 @@ Determine the OASIS path to the Worker Node Client software for your worker node
 
 On the CE, in the `/etc/osg/config.d/10-storage.ini` file, set the `grid_dir` configuration setting to the path from the previous step.
 
-For more information, see the [OSG worker node environment documentation](../worker-node/using-wn.md) and the [CE configuration instructions](../other/configuration-with-osg-configure#storage).
-
 Once you finish making changes to configuration files on your CE, validate, fix, and apply the configuration:
 
 ```console
 root@host # osg-configure -v
 root@host # osg-configure -c
 ```
+
+For more information, see the [OSG worker node environment documentation](../worker-node/using-wn.md) and the
+[CE configuration instructions](../other/configuration-with-osg-configure#storage).
 
 Validating the Worker Node Client
 ---------------------------------

--- a/docs/worker-node/install-wn-tarball.md
+++ b/docs/worker-node/install-wn-tarball.md
@@ -1,26 +1,25 @@
-Installing and Using the Worker Node Client from Tarballs
-=========================================================
+Installing the Worker Node Client via Tarball
+=============================================
 
-Introduction
-------------
+The **OSG Worker Node Client** is a collection of software components that is expected to be added to every worker node
+that can run OSG jobs. It provides a common environment and a minimal set of common tools that all OSG jobs can expect
+to use. Contents of the worker node client can be found [here](install-wn.md#worker-node-contents).
 
-This document is intended to guide users through the process of installing the worker node software and configuring the installed worker node software. Contents of the worker node client can be found [here](install-wn.md#worker-node-contents).  Although this document is oriented to system administrators, any unprivileged user may install and use the client.
+!!! note
+    It is possible to install the Worker Node Client software in a variety of ways, depending on your local site:
 
-If you are installing the OSG worker node client following these instruction, remember to configure the `grid_dir` option on your CE - see [below](#configure-the-ce).
+    -   Install using a tarball (this guide) - useful when installing onto a shared filesystem for distribution to worker nodes
+    -   [Use from OASIS](install-wn-oasis.md) - useful when worker nodes already mount [CVMFS](install-cvmfs)
+    -   [Install using RPMs and Yum](install-wn.md) - useful when managing your worker nodes with a tool (e.g., Puppet, Chef) that can automate RPM installs
 
-About This Guide
-----------------
-
-The *OSG Worker Node Client* is a collection of software components that is expected to be added to every worker node that can run OSG jobs. It provides a common environment and a minimal set of common tools that all OSG jobs can expect to use.
-
-It is possible to install the Worker Node Client software in a variety of ways, depending on what works best for distributing and managing software at your site:  This guide is useful when installing onto a shared filesystem for distribution to worker nodes.  Other options include installing [via RPMs](install-wn.md) or providing the client [via OASIS (CVMFS)](install-wn-oasis).
+This document is intended to guide users through the process of installing the worker node software and configuring the
+installed worker node software.  Although this document is oriented to system administrators, any unprivileged user
+may install and use the client.
 
 Before starting, ensure the host has [a supported operating system](../release/supported_platforms.md).
 
-Download, Installation and Configuration
-----------------------------------------
-
-### Download the WN Client
+Download the WN Client
+----------------------
 
 Please pick the `osg-wn-client` tarball that is appropriate for your distribution and architecture. You will find them in <https://repo.opensciencegrid.org/tarball-install/> .
 
@@ -35,7 +34,8 @@ For OSG 3.4:
 -   [Binaries for 64-bit RHEL6](https://repo.opensciencegrid.org/tarball-install/3.4/osg-wn-client-latest.el6.x86_64.tar.gz)
 -   [Binaries for RHEL7](https://repo.opensciencegrid.org/tarball-install/3.4/osg-wn-client-latest.el7.x86_64.tar.gz)
 
-### Install the WN Client
+Install the WN Client
+---------------------
 
 1.  Unpack the tarball.
 2.  Move the directory that was created to where you want the tarball client to be.
@@ -61,7 +61,8 @@ root@host # osg-ca-manage setupCA --url osg
 root@host # fetch-crl
 ```
 
-#### Configure the CE
+Configure the CE
+----------------
 
 Using the wn-client software installed from the tarball will require a few changes on the compute element so that the resource's configuration can be correctly reported.
 
@@ -94,13 +95,10 @@ Here is what they should look like. (Note: fill in `<OSG_LOCATION>` with the ful
 
 You might want to configure proxy settings in `$OSG_LOCATION/etc/fetch-crl.conf`.
 
-### Starting and Enabling Services
+### Enabling and Disabling Services
 
-To start the services you must edit your cron with **`crontab -e`** and add the lines above.
-
-### Stopping and Disabling Services
-
-To stop the services you must edit your cron with **`crontab -e`** and remove or comment the lines above.
+To enable the CRL updates, you must edit your cron with **`crontab -e`** and add the lines above.  To disable, remove
+the lines from the `crontab`.
 
 Validing the Worker Node Client
 -------------------------------

--- a/docs/worker-node/install-wn.md
+++ b/docs/worker-node/install-wn.md
@@ -1,18 +1,19 @@
-Installing and Using the Worker Node Client From RPMs
-=====================================================
+Installing the Worker Node Client From RPMs
+===========================================
 
-About This Guide
-----------------
+The **OSG Worker Node Client** is a collection of software components that is expected to be added to every worker node
+that can run OSG jobs. It provides a common environment and a minimal set of common tools that all OSG jobs can expect
+to use. Contents of the worker node client can be found [here](install-wn.md#worker-node-contents).
 
-The **OSG Worker Node Client** is a collection of software components that is expected to be added to every worker node that can run OSG jobs. It provides a common environment and a minimal set of common tools that all OSG jobs can expect to use. See the reference section below for contents of the Worker Node Client.
+!!! note
+    It is possible to install the Worker Node Client software in a variety of ways, depending on your local site:
 
-It is possible to install the Worker Node Client software in a variety of ways, depending on what works best for distributing and managing software at your site:
+    -   Install using RPMs and Yum (this guide) - useful when managing your worker nodes with a tool (e.g., Puppet, Chef) that can automate RPM installs
+    -   [Use from OASIS](install-wn-oasis.md) - useful when worker nodes already mount [CVMFS](install-cvmfs)
+    -   [Install using a tarball](install-wn-tarball.md) - useful when installing onto a shared filesystem for distribution to worker nodes
 
--   Install using RPMs and Yum (this guide) - useful when managing your worker nodes with a tool (e.g., Puppet, Chef) that can automate RPM installs
--   [Install using a tarball](install-wn-tarball.md) - useful when installing onto a shared filesystem for distribution to worker nodes
--   [Use from OASIS](install-wn-oasis.md) - useful when worker nodes already mount [CVMFS](install-cvmfs)
-
-This document is intended to guide system administrators through the process of configuring a site to make the Worker Node Client software available from an RPM.
+This document is intended to guide system administrators through the process of configuring a site to make the Worker
+Node Client software available from an RPM.
 
 Before Starting
 ---------------

--- a/docs/worker-node/using-wn.md
+++ b/docs/worker-node/using-wn.md
@@ -1,6 +1,6 @@
 
-Introduction
-============
+Worker Node Overview
+====================
 
 The Worker Node Client is a collection of useful software components that is expected to be on every OSG worker node. In addition, a job running on a worker node can access a handful of environment variables that can be used to locate resources.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,9 +20,9 @@ pages:
   - 'Submitting to HTCondor-CE': 'compute-element/submit-htcondor-ce.md'
 - Worker Node:
   - 'Worker Node Overview': 'worker-node/using-wn.md'
-  - 'Worker Node (RPM install)': 'worker-node/install-wn.md'
-  - 'Worker Node (tarball install)': 'worker-node/install-wn-tarball.md'
-  - 'Worker Node (OASIS install)': 'worker-node/install-wn-oasis.md'
+  - 'Worker Node via RPM': 'worker-node/install-wn.md'
+  - 'Worker Node via Tarball': 'worker-node/install-wn-tarball.md'
+  - 'Worker Node via OASIS': 'worker-node/install-wn-oasis.md'
   - 'CVMFS': 'worker-node/install-cvmfs.md'
   - 'Singularity': 'worker-node/install-singularity.md'
 - Data:


### PR DESCRIPTION
This tries to streamline / clarify the introduction of the three WN install variants.  Now, each of them has the same introductory text and mostly have the same header names.

Remove unnecessary / empty header levels.