### PR TITLE
Fixup broken 404.html from mkdocs

### DIFF
--- a/osgthedocs/404.html
+++ b/osgthedocs/404.html
@@ -1,7 +1,0 @@
-{% block content %}
-
-  <h1 id="404-page-not-found">404</h1>
-
-  <p><strong>Page not found</strong></p>
-
-{% endblock %}


### PR DESCRIPTION
404 looks good on [docs-itb](https://opensciencegrid.github.io/docs-itb/foobar) vs [production](https://opensciencegrid.github.io/docs/foobar). I originally tried to ignore the offending URLs via linkchecker config but couldn't get that to work because linkchecker is the worst.