### PR TITLE
remove CVMFS_HASH_ALGORITHM=shake128 until cvmfs-server-2.4.4

### DIFF
--- a/docs/data/external-oasis-repos.md
+++ b/docs/data/external-oasis-repos.md
@@ -114,7 +114,6 @@ Next, adjust the configuration in the repository as follows.
     CVMFS_AUTO_TAG_TIMESPAN="2 weeks ago"
     CVMFS_IGNORE_XDIR_HARDLINKS=true
     CVMFS_GENERATE_LEGACY_BULK_CHUNKS=false
-    CVMFS_HASH_ALGORITHM=shake128
     CVMFS_AUTOCATALOGS=true
     CVMFS_ENFORCE_LIMITS=true
     CVMFS_FORCE_REMOUNT_WARNING=false


### PR DESCRIPTION
There's a [bug](https://sft.its.cern.ch/jira/browse/CVM-1446) in cvmfs-2.4.3 and earlier that means we should not yet recommend CVMFS_HASH_ALGORITHM=shake128.