### PR TITLE
Filebeats schedd

### DIFF
--- a/docs/other/schedd-filebeats.md
+++ b/docs/other/schedd-filebeats.md
@@ -1,0 +1,80 @@
+Installation of FileBeats for Submit nodes
+==========================================
+
+This document is for frontend administrators. It describes the installation of [Filebeats](https://www.elastic.co/products/beats/filebeat) to continusly upload the HTCondor submit hosts transfer log to Elastic Search.
+
+
+Introduction
+=================
+
+A submit host (HTCondor schedd) is a login node where users submit jobs to the Grid. One interesting log that it produces is the TransferLog. The TransferLogs report all the transfers of files between compute node sand submit nodes. In this guide we describe the installation of Filebeats to upload this log to Elastic Search.
+
+Installation
+=================
+
+FileBeat Installation
+----------------------------------------------
+For the installation of filebeats follow the  official instruction to set up the repositories and install filebeats as described [here](https://www.elastic.co/guide/en/beats/filebeat/current/setup-repositories.html).
+
+Configuration
+================
+
+Configuration of Filebeats
+-----------------------------------------
+
+The configuration of filebeats revovles around this file `/etc/filebeat/filebeat.yml`. Bellow are the steps to modify the different sections of this file
+
+1. The input section should look like this:
+
+     ::: file
+     - input_type: log
+     paths:
+     - /var/log/condor/XferStatsLog
+
+1. The output logstash section should look like:
+
+   ```file
+      #----------------------------- Logstash output --------------------------------
+      output.logstash:
+      # The Logstash hosts
+      hosts: ["gracc.opensciencegrid.org:6938"]
+
+      # Optional SSL. By default is off. 
+      # List of root certificates for HTTPS server verifications
+      ssl.certificate_authorities: ["/etc/grid-security/certificates/cilogon-osg.pem"]
+
+      # Certificate for SSL client authentication
+      ssl.certificate: "/etc/grid-security/hostcert.pem"
+
+      # Client Certificate Key
+      ssl.key: "/etc/grid-security/hostkey.pem"
+   ```
+
+Configuration of HTCondor
+-----------------------------------------
+
+
+Client Site Installation 
+------------------------------------------------------------------
+
+The Network Performance Toolkit is installed with the OSG Client. Specifically, the tools included are: BWCTL, NDT and OWAMP (bwctl-client, bwctl-server, bwctl, ndt, owamp-client). NPAD is currently not in OSG client.
+
+If you just want to install the OSG command line clients you can do the following::
+
+``` console
+yum install bwctl-client
+yum install owamp-client
+yum install ndt-client
+yum install npad-client
+```
+
+You may install these utilities separately as RPM using yum by following the [perfSONAR](http://www.perfsonar.net/about) instructions. The packages are in the OSG repository, some of them with a separate client or server version, available for the OSG supported platforms:
+
+-   NDT: ndt
+-   OWAMP: owamp, owamp-client, owamp-server
+-   BWCTL: bwctl, bwctl-client, bwctl-server
+-   NPAD: npad
+
+Server Site Installation 
+------------------------------------------------------------------
+

--- a/docs/other/schedd-filebeats.md
+++ b/docs/other/schedd-filebeats.md
@@ -1,13 +1,13 @@
 Installation of FileBeats for Submit nodes
 ==========================================
 
-This document is for frontend administrators. It describes the installation of [Filebeats](https://www.elastic.co/products/beats/filebeat) to continusly upload the HTCondor submit host transfer log to Elastic Search.
+This document is for frontend administrators. It describes the installation of [Filebeats](https://www.elastic.co/products/beats/filebeat) to continuously upload the HTCondor submit host transfer log to Elastic Search.
 
 
 Introduction
 =================
 
-A submit host (HTCondor schedd) is a login node where users submit jobs to the Grid. One interesting log that it produces is the TransferLog. The TransferLogs report all the transfers of files between compute node sand submit nodes. In this guide we describe the installation of Filebeats to upload this log to Elastic Search.
+A submit host (HTCondor schedd) is a login node where users submit jobs to the Grid. One interesting log that it produces is the TransferLog. The TransferLogs report all the transfers of files between compute node and submit nodes. In this guide we describe the installation of Filebeats to upload this log to Elastic Search.
 
 Installation
 =================
@@ -22,7 +22,7 @@ Configuration
 Configuration of Filebeats
 -----------------------------------------
 
-The configuration of filebeats revovles around this file `/etc/filebeat/filebeat.yml`. Bellow are the steps to modify the different sections of this file
+The configuration of filebeats revolves around this file `/etc/filebeat/filebeat.yml`. Bellow are the steps to modify the different sections of this file
 
 1. The `Filebeat Prospectors` section, the input should look like this:
 
@@ -92,7 +92,7 @@ Configuration of HTCondor
 
 For the configuration of the HTCondor submit host to use the TransferLog follow the next instructions:
 
-1. Create a file named `/etc/condor/config.d/50-transferLog.config` with the following contnets
+1. Create a file named `/etc/condor/config.d/50-transferLog.config` with the following contents:
     
         :::file
         SHADOW_DEBUG = D_STATS

--- a/docs/other/schedd-filebeats.md
+++ b/docs/other/schedd-filebeats.md
@@ -84,12 +84,12 @@ For the configuration of the HTCondor submit host to use the TransferLog follow 
         SHADOW_STATS_LOG = $(LOG)/XferStatsLog
         STARTER_STATS_LOG = $(LOG)/XferStatsLog
 
-2. Reconfigure condor:
+1. Reconfigure condor:
 
         :::console
         root@host #condor_reconfig
 
-3. Make sure that after a while the new log `/var/log/XferStatsLog` is present.
+1. Make sure that after a while the new log `/var/log/XferStatsLog` is present.
 
 
 

--- a/docs/other/schedd-filebeats.md
+++ b/docs/other/schedd-filebeats.md
@@ -1,3 +1,6 @@
+!!!warning
+    This is a technology preview document and will probably change content and location withouth notice.
+
 Installation of FileBeats for Submit nodes
 ==========================================
 

--- a/docs/other/schedd-filebeats.md
+++ b/docs/other/schedd-filebeats.md
@@ -24,7 +24,7 @@ Configuration of Filebeats
 
 The configuration of filebeats revovles around this file `/etc/filebeat/filebeat.yml`. Bellow are the steps to modify the different sections of this file
 
-1. The input section should look like this:
+1. The `Filebeat Prospectors` section, the input should look like this:
 
         :::file
         - input_type: log
@@ -71,6 +71,21 @@ The configuration of filebeats revovles around this file `/etc/filebeat/filebeat
 
         :::console
         root@host # service filebeat start
+
+1. The general section should look like this:
+
+        :::file
+        #================================ General =====================================
+
+        name: %RED%<hostname>%ENDCOLOR%
+        tags: ["xfer-log"]
+
+        # Optional fields that you can specify to add additional information to the
+        # output.
+        #fields:
+        #  env: staging
+
+
 
 Configuration of HTCondor
 -----------------------------------------

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,7 @@ pages:
   - 'GlideinWMS Frontend': 'other/install-gwms-frontend.md'
   - 'Install a CVMFS Stratum 1': 'other/install-cvmfs-stratum1.md'
   - 'Network Performance Toolkit': 'other/network-performance-toolkit.md'
+  - 'Transfer log filebeats installation': 'other/schedd-filebeats.md'
 - Release Information:
   - 'Release Notes': 'release/notes.md'
   - 'OSG Release Series': 'release/release_series.md'


### PR DESCRIPTION
This document is for instruction for frontend admins to enable sending the schedd transfer Logs to ES. @djw8605 and I worked on setting this up on osg-connect and it worked. This is basically the same instructions that @LincolnBryant and @jlstephen used to set it up in osg-connect.