### PR TITLE
SOFTWARE-2522 (GridFTP limits)Try 2

### DIFF
--- a/docs/data/gridftp.md
+++ b/docs/data/gridftp.md
@@ -111,6 +111,27 @@ All other configuration settings should be suitable for most purposes. However, 
 
 ### Optional configuration
 
+#### Setting transfer limits
+
+Create file named `/etc/sysconfig/gridftp-limits`. To set a limit on the total or per-user number of transfers, set the following configuration:
+
+    :::file
+    export GRIDFTP_TRANSFER_LIMIT="80"
+    export GRIDFTP_DEFAULT_USER_TRANSFER_LIMIT="50"
+    export GRIDFTP_LIGO_USER_TRANSFER_LIMIT="40"
+    export GRIDFTP_CMS_USER_TRANSFER_LIMIT="20"
+
+In the above configuration:
+
+- There would be no more than 80 transfers going at a time, across all users.
+- By default, any single user can have no more than 50 transfers at a time.
+- The `ligo` user has a more stringent limit of 40 transfers at a time.
+- The `cms` user has an even more stringent limit of 20 transfers at a time.
+
+
+!!!note
+    This limits are per gridftp server. If you have several gridftp servers you may want to have this limits divided by the number of gridftp servers at your site.
+
 #### Modifying the environment
 
 Environment variables are stored in `/etc/sysconfig/globus-gridftp-server` which is sourced on service startup.  If you want to change LCMAPS log levels, or GridFTP port ranges, you can edit them there.

--- a/docs/data/gridftp.md
+++ b/docs/data/gridftp.md
@@ -111,22 +111,22 @@ All other configuration settings should be suitable for most purposes. However, 
 
 ### Optional configuration
 
-#### Setting transfer limits
+#### Setting transfer limits for GridFTP - HDFS
 
-Create file named `/etc/sysconfig/gridftp-limits`. To set a limit on the total or per-user number of transfers, set the following configuration:
+Create file named `/etc/sysconfig/gridftp-hdfs`. To set a limit on the total or per-user number of transfers, set the following configuration:
 
     :::file
     export GRIDFTP_TRANSFER_LIMIT="80"
     export GRIDFTP_DEFAULT_USER_TRANSFER_LIMIT="50"
-    export GRIDFTP_LIGO_USER_TRANSFER_LIMIT="40"
-    export GRIDFTP_CMS_USER_TRANSFER_LIMIT="20"
+    export GRIDFTP_%RED%<UNIX USERNAME>%ENDCOLOR%_USER_TRANSFER_LIMIT="40"
+
 
 In the above configuration:
 
 - There would be no more than 80 transfers going at a time, across all users.
 - By default, any single user can have no more than 50 transfers at a time.
-- The `ligo` user has a more stringent limit of 40 transfers at a time.
-- The `cms` user has an even more stringent limit of 20 transfers at a time.
+- The `%RED%<UNIX USERNAME>%ENDCOLOR%` user has a more stringent limit of 40 transfers at a time.
+
 
 
 !!!note

--- a/docs/data/gridftp.md
+++ b/docs/data/gridftp.md
@@ -111,23 +111,20 @@ All other configuration settings should be suitable for most purposes. However, 
 
 ### Optional configuration
 
-#### Setting transfer limits for GridFTP - HDFS
+#### Setting transfer limits for GridFTP-HDFS
 
-Create file named `/etc/sysconfig/gridftp-hdfs`. To set a limit on the total or per-user number of transfers, set the following configuration:
+To set a limit on the total or per-user number of transfers, create `/etc/sysconfig/gridftp-hdfs` and set the following configuration:
 
     :::file
     export GRIDFTP_TRANSFER_LIMIT="80"
     export GRIDFTP_DEFAULT_USER_TRANSFER_LIMIT="50"
     export GRIDFTP_%RED%<UNIX USERNAME>%ENDCOLOR%_USER_TRANSFER_LIMIT="40"
 
-
 In the above configuration:
 
 - There would be no more than 80 transfers going at a time, across all users.
 - By default, any single user can have no more than 50 transfers at a time.
 - The `%RED%<UNIX USERNAME>%ENDCOLOR%` user has a more stringent limit of 40 transfers at a time.
-
-
 
 !!!note
     This limits are per gridftp server. If you have several gridftp servers you may want to have this limits divided by the number of gridftp servers at your site.


### PR DESCRIPTION
@brianhlin, I had to create a different PR cause I did not know how to remove the commits. I applied all your suggestions. The limits are in the gridftp server so it does not matter the underlying source if its local disk, hdfs or xrootd. I changed the name of the file to make this more obvious