### PR TITLE
Drop instructions for setting 3.3 LCMAPS VOMS env var

### DIFF
--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -129,13 +129,7 @@ In OSG 3.4, the LCMAPS VOMS plugin is the only available authentication solution
 
 #### Authentication with the LCMAPS VOMS plugin
 
-To configure your CE to use the LCMAPS VOMS plugin:
-
-1. If you are using OSG 3.3, add the following line to `/etc/sysconfig/condor-ce`:
-
-        export LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1
-
-2. Follow the instructions in [the LCMAPS VOMS plugin installation and configuration document](../security/lcmaps-voms-authentication) to prepare the LCMAPS VOMS plugin
+To configure your CE to use the LCMAPS VOMS plugin, follow the instructions in [the LCMAPS VOMS plugin document](/security/lcmaps-voms-authentication#configuring-the-lcmaps-voms-plugin) to prepare the LCMAPS VOMS plugin.
 
 !!! note
     If your local batch system is HTCondor, it will attempt to utilize the LCMAPS callouts if enabled in the `condor_mapfile`. If this is not the desired behavior, set `GSI_AUTHZ_CONF=/dev/null` in the local HTCondor configuration.

--- a/docs/data/gridftp.md
+++ b/docs/data/gridftp.md
@@ -52,14 +52,7 @@ In OSG 3.4, the LCMAPS VOMS plugin is the only available authentication solution
 
 #### Authentication with the LCMAPS VOMS plugin
 
-1.  Add the following line to `/etc/sysconfig/globus-gridftp-server`:
-
-        :::shell
-        export LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1
-
-    This should _only_ be done for OSG 3.3; it is unnecessary for OSG 3.4.
-
-2.  Follow the instructions in [the LCMAPS VOMS plugin installation and configuration document](../security/lcmaps-voms-authentication) to prepare the LCMAPS VOMS plugin.
+To configure your GridFTP server to use the LCMAPS VOMS plugin, follow the instructions in [the LCMAPS VOMS plugin document](/security/lcmaps-voms-authentication#configuring-the-lcmaps-voms-plugin) to prepare the LCMAPS VOMS plugin.
 
 !!! note
     This is the suggested mechanism for all new installs.

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -33,13 +33,9 @@ To install the LCMAPS VOMS plugin, make sure that your host is up to date before
 Configuring the LCMAPS VOMS Plugin
 ----------------------------------
 
-The following section describes the steps required to configure the LCMAPS VOMS plugin for authentication. If you are using OSG 3.3 packages, there are software-specific instructions that must be followed for [HTCondor-CE](../compute-element/install-htcondor-ce), [GridFTP](../data/gridftp), and [XRootD](../data/install-xrootd). To check if you are running OSG 3.3, run the following command:
-
-``` console
-root@host # rpm -q --queryformat="%{VERSION}\n" osg-release
-```
-
-Additionally, there is [optional configuration](#optional-configuration) if you need to make changes to the default mappings.
+The following section describes the steps required to configure the LCMAPS VOMS plugin for authentication.
+Additionally, there are [optional configuration](#optional-configuration) instructions if you need to make changes to
+the default mappings, or migrate from edg-mkgridmap or GUMS.
 
 
 ### Enabling the LCMAPS VOMS plugin

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -130,13 +130,6 @@ The program edg-mkgridmap (found in the package `edg-mkgridmap`), used for authe
 
     * If you do not have a local grid mapfile, remove `/etc/grid-security/grid-mapfile`.
 
-1.  If you are remaining on OSG 3.3, ensure that the you have set `export LLGT_VOMS_ENABLE_CREDENTIAL_CHECK=1` in the appropriate file and restart the service. If you have updated your host to OSG 3.4, skip to the next step.
-
-    | **If your host is a(n)...** | **Add the aforementioned line to...**  | **And restart this service...** |
-    |:----------------------------|:---------------------------------------| :------------------------------ |
-    | HTCondor-CE                 | `/etc/sysconfig/condor-ce`             | `condor-ce`                     |
-    | GridFTP server              | `/etc/sysconfig/globus-gridftp-server` | `globus-gridftp-server`         |
-
 1.  If you are converting an HTCondor-CE host, remove the HTCondor-CE `GRIDMAP` configuration. Otherwise, skip to the next step.
 
     1. Find where `GRIDMAP` is set:


### PR DESCRIPTION
No longer necessary as of lcmaps-1.6.6-1.9.osg33