### PR TITLE
Remove LBL links for bestman2 docs.

### DIFF
--- a/docs/data/bestman-install.md
+++ b/docs/data/bestman-install.md
@@ -461,15 +461,10 @@ For a full set of help options, see the [Help Procedure](../common/help).
 References
 ==========
 
-* [BeStMan official website](http://sdm.lbl.gov/bestman)
-    * [BeStMan User guides](http://sdm.lbl.gov/bestman/docs/bestman-guide.html)
-    * [BeStMan FAQ](http://sdm.lbl.gov/bestman/docs/bestman-faq.html)
 * [SLAC Gateway mode Instruction](http://wt2.slac.stanford.edu/xrootdfs/bestman-gateway.html) - SLAC guide on gateway mode
 * [US ATLAS instruction page](http://www.usatlas.bnl.gov/twiki/bin/view/Admins/BestMan)
-* [SRM specifications and collaboration](http://sdm.lbl.gov/srm-wg) - from SRM collaboration working group
 * [S2](https://github.com/dCache/s2) - A SRM v2.2 test suite from CERN. It provides basic functionality tests based on use cases, and cross-copy tests, as part of the certification process and supports file access/transfer protocols: rfio, dcap, gsidcap, gsiftp
 * [SHA-2 compliance page](https://opensciencegrid.github.io/technology/projects/sha2-support/)
-* [Bestman scalability tuning](https://sdm.lbl.gov/twiki/bin/view/Software/BeStMan/BeStMan2Guide/ScalabilityNotes)
 
 Known Issues
 ============


### PR DESCRIPTION
The LBL links for bestman2 are periodically broken and increasingly less relevant, especially as we near the end of the support.

I don't see much value in including these as a reference (after all, we don't expect to have any new bestman2 services in the next 2.5 months), they can always be found via Google, and they have a noticable cost because of how often they break the CI tests.