### PR TITLE
Add CVMFS as a singularity requirement

### DIFF
--- a/docs/worker-node/install-singularity.md
+++ b/docs/worker-node/install-singularity.md
@@ -41,9 +41,9 @@ Before Starting
 
 As with all OSG software installations, there are some one-time (per host) steps to prepare in advance:
 
-- Ensure the host has [a supported operating system](../release/supported_platforms)
+- Ensure the host has [a supported operating system](/release/supported_platforms)
 - Obtain root access to the host
-- If you're installing singularity, prepare the [required Yum repositories](../common/yum)
+- If you're installing singularity, prepare the [required Yum repositories](/common/yum)
 
 !!! note "Validation Steps"
     The validation steps below require CVMFS to be installed.  Follow the steps on the [CVMFS Installation](/worker-node/install-cvmfs) page.

--- a/docs/worker-node/install-singularity.md
+++ b/docs/worker-node/install-singularity.md
@@ -44,9 +44,7 @@ As with all OSG software installations, there are some one-time (per host) steps
 - Ensure the host has [a supported operating system](/release/supported_platforms)
 - Obtain root access to the host
 - Prepare the [required Yum repositories](/common/yum)
-
-!!! note "Validation Steps"
-    The validation steps below require CVMFS to be installed.  Follow the steps on the [CVMFS Installation](/worker-node/install-cvmfs) page.
+- A [CVMFS installation](/worker-node/install-cvmfs) for Singularity image distribution
 
 Choosing Privileged vs Unprivileged Singularity
 -----------------------------------------------

--- a/docs/worker-node/install-singularity.md
+++ b/docs/worker-node/install-singularity.md
@@ -43,7 +43,7 @@ As with all OSG software installations, there are some one-time (per host) steps
 
 - Ensure the host has [a supported operating system](/release/supported_platforms)
 - Obtain root access to the host
-- If you're installing singularity, prepare the [required Yum repositories](/common/yum)
+- Prepare the [required Yum repositories](/common/yum)
 
 !!! note "Validation Steps"
     The validation steps below require CVMFS to be installed.  Follow the steps on the [CVMFS Installation](/worker-node/install-cvmfs) page.


### PR DESCRIPTION
Although it's not a strict requirement, Singularity in the OSG needs CVMFS for image distribution perhaps this is only true for a few VOs and if that's the case, we can add a disclaimer.