### PR TITLE
Registration doc (SOFTWARE-3344)

### DIFF
--- a/docs/common/registration.md
+++ b/docs/common/registration.md
@@ -1,0 +1,87 @@
+Registering in the OSG
+======================
+
+The OSG keeps a registry containing active projects, virtual organizations (VOs), resources, and resource
+downtimes in the [topology Github repository](https://github.com/opensciencegrid/topology/).
+This registry is used for [accounting data](https://gracc.opensciencegrid.org), contact information, and resource
+availability, particularly if your site is part of the [World LHC Computing Grid](https://en.wikipedia.org/wiki/Worldwide_LHC_Computing_Grid)
+(WLCG).
+
+Use this page below to learn how to register in the OSG.
+
+How to Register
+---------------
+
+OSG registry information is stored in [YAML files](https://en.wikipedia.org/wiki/YAML) in the topology Github
+repository.
+The formatting and locations of the YAML files for the different types of registration data are described
+in the following table:
+
+| The following data... | Is defined by template file...       | And should be copied to location, relative to the Git root directory... |
+|-----------------------|--------------------------------------|-------------------------------------------------------------------------|
+| Project               | `template-project.yaml`              | `projects/<PROJECT NAME>.yaml`                                          |
+| Resource Downtime     | `template-downtime.yaml`             | `topology/<FACILITY>/<SITE>/<RESOURCE GROUP NAME>_downtime.yaml`        |
+| Resource Topology     | `template-resourcegroup.yaml`        | `topology/<FACILITY>/<SITE>/<RESOURCE GROUP NAME>.yaml`                 |
+| Virtual Organization  | `template-virtual-organization.yaml` | `virtual-organizations/<VO NAME>.yaml`                                  |
+
+The comments in the template files explain the structure and the meaning of the data.
+
+!!! note
+    File and directory names _must_ match the name of your project, VO, facility, site, or resource group, as
+    appropriate.
+    This includes case and spaces.
+
+### New registrations ###
+
+To create a new resource group, project, or VO, please create the YAML file according to the table above, and use the
+corresponding template file to fill in the appropriate information.
+If you do not feel comfortable creating the new file yourself, send an email to <help@opensciencegrid.org> with
+details about your resource group, project, or VO.
+
+### Updating existing registrations ###
+
+To update the data for your site resources, project, or VO, make and submit your changes using one of the following
+methods:
+
+- [Modify the corresponding YAML file](https://help.github.com/articles/editing-files-in-your-repository/) and submit
+  your changes as a GitHub pull request.
+- Send an email to <help@opensciencegrid.org> requesting your desired changes.
+
+For definitions for the various fields, consult the corresponding template file for the type of data you are updating.
+
+
+### How to Register Downtime ###
+
+Downtime is a period of time for which one or more services you provide are unavailable.
+You should register downtime if one of these is true:
+
+-  your site is part of the WLCG
+-  your CE is one of the services affected
+
+1. Find the file that should contain downtime information about resources you own.
+   It is named `topology/<FACILITY>/<SITE>/<RESOURCE GROUP NAME>_downtime.yaml`.
+
+   For example, `topology/University of Wisconsin/GLOW/GLOW.yaml` has the corresponding downtime file
+   `topology/University of Wisconsin/GLOW/GLOW_downtime.yaml`.
+
+   If the downtime file does not exist, create it.
+
+   To find out what resource group a host is in, search for the FQDN of the host with something like:
+
+   `grep -F "<FQDN>" topology/*/*/*.yaml | grep -Fv _downtime.yaml | grep -Fv SITE.yaml`
+
+   If the above command returns nothing, then the host is not registered in the topology data
+   and you don't need to register downtime for it.
+
+2. Add the contents of `template-downtime.yaml` to the end of the downtime file in the path above.
+
+3. Follow the instructions in the comments to fill out the necessary fields.
+
+   **Note:** Make sure the info you add matches the formatting and indentation of the template or the other downtime entries in the file.
+   In particular, make sure no additional indentation gets added when pasting in the new data.
+
+4. Submit your changes as a GitHub pull request.
+
+Alternatively, send an email to <help@opensciencegrid.org> requesting your desired changes.
+
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,3 +136,9 @@ Scale Up Site to Full Production
 --------------------------------
 
 After successfully running all the pilot jobs that are submitted by the test factory and verifying your site reports, your site will be deemed production ready. No action is required on your end, factory operations will start submitting pilot jobs from the production factory.
+
+Maintain the Site
+-----------------
+
+In order to continue receiving jobs from the OSG, you must [register](/common/registration.md) any publicly facing
+resources with OSG software: HTCondor-CE, Frontier Squid, GridFTP, and/or XRootD.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,8 @@ If you are not a site adminstrator:
 
 - If you are a **researcher** interested in using OSG resources, you may want to view our
   [user documentation](https://support.opensciencegrid.org/support/home).
-- If you'd like to learn more about the OSG and our mission, visit the OSG consortium's [homepage](https://www.opensciencegrid.org/).
+- If you'd like to learn more about the OSG and our mission, visit the OSG consortium's
+  [homepage](https://www.opensciencegrid.org/).
 
 This document outlines the overall installation process for an OSG site and provides many links into detailed
 installation, configuration, troubleshooting, and similar pages. If you do not see software-related technical
@@ -18,7 +19,10 @@ documentation listed here, try the search bar at the top or contacting us at
 Plan the Site
 -------------
 
-If you have not done so already, [plan the overall architecture of your OSG site](site-planning). It is recommended that your plan be sufficiently detailed to include the OSG hosts that are needed and the main software components for each host. Be sure to consider [the operating systems that OSG supports](release/supported_platforms). For example, a basic site might include:
+If you have not done so already, [plan the overall architecture of your OSG site](site-planning).
+It is recommended that your plan be sufficiently detailed to include the OSG hosts that are needed and the main software
+components for each host.
+Be sure to consider [the operating systems that OSG supports](release/supported_platforms). For example, a basic site might include:
 
 | Purpose              | Host                                | Major Software                                           |
 |:---------------------|:------------------------------------|:---------------------------------------------------------|
@@ -28,16 +32,27 @@ If you have not done so already, [plan the overall architecture of your OSG site
 Prepare the Batch System
 ------------------------
 
-The assumption is that you have an existing batch system at your site. Currently, we support [HTCondor](http://research.cs.wisc.edu/htcondor/), [LSF](https://www.ibm.com/us-en/marketplace/hpc-workload-management), [PBS](http://www.pbsworks.com) and [TORQUE](http://www.adaptivecomputing.com/products/open-source/torque/), [SGE](http://en.wikipedia.org/wiki/Oracle_Grid_Engine), and [Slurm](http://slurm.schedmd.com) batch systems.
+The assumption is that you have an existing batch system at your site.
+Currently, we support [HTCondor](http://research.cs.wisc.edu/htcondor/),
+[LSF](https://www.ibm.com/us-en/marketplace/hpc-workload-management), [PBS](http://www.pbsworks.com) and
+[TORQUE](http://www.adaptivecomputing.com/products/open-source/torque/),
+[SGE](http://en.wikipedia.org/wiki/Oracle_Grid_Engine), and [Slurm](http://slurm.schedmd.com) batch systems.
 
-For smaller sites (less than 50 worker nodes), the most common way to add a site to OSG is to install the OSG Compute Element (CE) on the central host of your batch system.  At such a site - especially if you have minimal time to maintain a CE - you may want to contact <mailto:help@opensciencegrid.org> to ask about using an OSG-hosted CE instead of running your own.  Before proceeding with an install, be sure that you can submit and successfully run a job from your OSG CE host into your batch system.
+For smaller sites (less than 50 worker nodes), the most common way to add a site to OSG is to install the OSG Compute
+Element (CE) on the central host of your batch system.
+At such a site - especially if you have minimal time to maintain a CE - you may want to contact
+<mailto:help@opensciencegrid.org> to ask about using an OSG-hosted CE instead of running your own.
+Before proceeding with an install, be sure that you can submit and successfully run a job from your OSG CE host into
+your batch system.
 
 Add OSG Software
 ----------------
 
-If necessary, provision all OSG hosts that are in your site plan that do not exist yet.  The general steps to installing an OSG site are:
+If necessary, provision all OSG hosts that are in your site plan that do not exist yet.
+The general steps to installing an OSG site are:
 
-1. Install [OSG Yum Repos](release/yum-basics) and the [Compute Element software](#installing-and-configuring-the-compute-element) on your CE host
+1. Install [OSG Yum Repos](release/yum-basics) and the [Compute Element software](#installing-and-configuring-the-compute-element)
+   on your CE host
 1. Install the [Worker Node client](#adding-osg-software-to-worker-nodes) on your worker nodes.
 1. Install [optional software](#installing-and-configuring-other-services) to increase the capabilities of your site.
 1. [Test the OSG installation](#test-osg-software).
@@ -45,7 +60,11 @@ If necessary, provision all OSG hosts that are in your site plan that do not exi
 1. Verify your [site's accounting](#verify-reporting-and-monitoring).
 
 !!! note
-    For sites with more than a handful of worker nodes, it is recommended to use some sort of configuration management tool to install, configure, and maintain your site. While beyond the scope of OSG’s documentation to explain how to select and use such a system, some popular configuration management tools are [Puppet](http://puppetlabs.com), [Chef](https://www.chef.io), [Ansible](https://www.ansible.com), and [CFEngine](http://cfengine.com).
+    For sites with more than a handful of worker nodes, it is recommended to use some sort of configuration management
+    tool to install, configure, and maintain your site.
+    While beyond the scope of OSG’s documentation to explain how to select and use such a system, some popular
+    configuration management tools are [Puppet](http://puppetlabs.com), [Chef](https://www.chef.io),
+    [Ansible](https://www.ansible.com), and [CFEngine](http://cfengine.com).
 
 ### General Installation Instructions ###
 
@@ -76,10 +95,14 @@ If necessary, provision all OSG hosts that are in your site plan that do not exi
 -   [Worker Node (WN) Client Overview](worker-node/using-wn)
 -   Install the WN client software on every worker node – pick a method:
     -   [Using RPMs](worker-node/install-wn) – useful when managing your worker nodes with a tool (e.g., Puppet, Chef)
-    -   [Using a tarball](worker-node/install-wn-tarball) – useful for installation onto a shared filesystem (does not require root access)
-    -   [Using OASIS](worker-node/install-wn-oasis) – useful when [CVMFS](worker-node/install-cvmfs) is already mounted on your worker nodes
--   (optional) [Install the CernVM-FS client](worker-node/install-cvmfs) to make it easy for user jobs to use needed software from OSG's OASIS repositories
--   (optional) [Install singularity on the OSG worker node](worker-node/install-singularity), to allow pilot jobs to isolate user jobs.
+    -   [Using a tarball](worker-node/install-wn-tarball) – useful for installation onto a shared filesystem (does not
+        require root access)
+    -   [Using OASIS](worker-node/install-wn-oasis) – useful when [CVMFS](worker-node/install-cvmfs) is already mounted
+        on your worker nodes
+-   (optional) [Install the CernVM-FS client](worker-node/install-cvmfs) to make it easy for user jobs to use needed
+    software from OSG's OASIS repositories
+-   (optional) [Install singularity on the OSG worker node](worker-node/install-singularity), to allow pilot jobs to
+    isolate user jobs.
 
 
 ### Installing and Configuring Other Services ###
@@ -91,7 +114,8 @@ installed [CVMFS](worker-node/install-cvmfs) on your worker nodes.
 -   Storage element:
     -   Existing POSIX-based systems (such as NFS, Lustre, or GPFS):
         -   [Install standalone OSG GridFTP](data/gridftp): GridFTP server
-        -   (optional) [Install load-balanced OSG GridFTP](data/load-balanced-gridftp): when a single GridFTP server isn't enough
+        -   (optional) [Install load-balanced OSG GridFTP](data/load-balanced-gridftp): when a single GridFTP server
+            isn't enough
     -   Hadoop Distributed File System (HDFS):
         -   [Hadoop Overview](data/hadoop-overview): HDFS information, planning, and guides
     -   XRootD:
@@ -99,30 +123,36 @@ installed [CVMFS](worker-node/install-cvmfs) on your worker nodes.
         -   [Install XRootD Server](data/install-xrootd): XRootD redirector installation
 -   RSV monitoring to monitor and report to OSG on the health of your site
     -   [Install RSV](monitoring/install-rsv)
--   [Install the GlideinWMS VO Frontend](other/install-gwms-frontend) if your want your users’ jobs to run on the OSG
+-   [Install the GlideinWMS VO Frontend](other/install-gwms-frontend) if your want your users' jobs to run on the OSG
     -   [Install the RSV GlideinWMS Tester](monitoring/install-rsv-gwms-tester) if you want to test your front-end's
         ability to submit jobs to sites in the OSG
 
 Test OSG Software
 -----------------
 
-It is useful to test *manual* submission of jobs from inside and outside of your site through your CE to your batch system. If this process does not work manually, it will probably not work for the glideinWMS pilot factory either.
+It is useful to test *manual* submission of jobs from inside and outside of your site through your CE to your batch
+system.
+If this process does not work manually, it will probably not work for the glideinWMS pilot factory either.
 
 -   [Test job submission into an HTCondor-CE](compute-element/submit-htcondor-ce)
 
 Start GlideinWMS Pilot Submissions
 ----------------------------------
 
-To begin running [GlideinWMS](http://glideinwms.fnal.gov/) pilot jobs at your site, e-mail <osg-gfactory-support@physics.ucsd.edu> and tell them that you want to start accepting Glideins. Please provide them with the following information:
+To begin running [GlideinWMS](http://glideinwms.fnal.gov/) pilot jobs at your site, e-mail
+<osg-gfactory-support@physics.ucsd.edu> and tell them that you want to start accepting Glideins.
+Please provide them with the following information:
 
 -   The fully qualified hostname of the CE
--   Resource/WLCG name
+-   Resource name
 -   Supported OS version of your worker nodes (e.g., EL6, EL7, or both)
 -   Support for multicore jobs
 -   Maximum job walltime
 -   Maximum job memory usage
 
-Once the factory team has enough information, they will start submitting pilots from the test factory to your CE. Initially, this will be one pilot at a time but once the factory verifies that pilot jobs are running successfully, that number will be ramped up to 10, then 100.
+Once the factory team has enough information, they will start submitting pilots from the test factory to your CE.
+Initially, this will be one pilot at a time but once the factory verifies that pilot jobs are running successfully, that
+number will be ramped up to 10, then 100.
 
 Verify Reporting and Monitoring
 -------------------------------
@@ -135,7 +165,9 @@ To verify that your site is correctly reporting to the OSG, check
 Scale Up Site to Full Production
 --------------------------------
 
-After successfully running all the pilot jobs that are submitted by the test factory and verifying your site reports, your site will be deemed production ready. No action is required on your end, factory operations will start submitting pilot jobs from the production factory.
+After successfully running all the pilot jobs that are submitted by the test factory and verifying your site reports,
+your site will be deemed production ready.
+No action is required on your end, factory operations will start submitting pilot jobs from the production factory.
 
 Maintain the Site
 -----------------

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ pages:
   - 'CA Certificates': 'common/ca.md'
   - 'Yum Repos': 'common/yum.md'
   - 'Configuration with OSG-Configure': 'other/configuration-with-osg-configure.md'
+  - 'Registration': 'common/registration.md'
 - Other:
   - 'Install GSI-enabled SSH': 'other/gsissh.md'
   - 'Install GlideinWMS Frontend': 'other/install-gwms-frontend.md'


### PR DESCRIPTION
I started a `Maintain the Site` section that only has a link to the registration doc atm. Down the line I envision the registration doc flow will look like this:

1. Generic registration information will live in the `registration.md`: 
    - Definitions for facility, site, resource group, and resource
    - How to figure out which YAML file to edit
    - Template file locations
    - Different types of contacts
    - ...
1. Specific procedural instructions at the end of each install doc, telling them to set `Inactive: True` (I'm not sure having it at the end always makes sense, e.g. the HTCondor-CE install doc has osg-configure instructions in the middle that need knowledge of the resource name)
1. Tell users to set `Inactive: False` in the `Scale Up Site to Full Production` section of `index.md`
1. Stress keeping registrations up to date in the `Maintain the Site` section of `index.md`