### PR TITLE
Add step to verify CE daemons

### DIFF
--- a/docs/compute-element/htcondor-ce-overview.md
+++ b/docs/compute-element/htcondor-ce-overview.md
@@ -37,7 +37,8 @@ delegate jobs by transforming and submitting them to the site’s batch system.
 Benefits of running the HTCondor-CE:
 
 -   **Scalability:** HTCondor-CE is capable of supporting job workloads of large sites
--   **Debugging tools:** HTCondor-CE offers [many tools to help troubleshoot](troubleshoot-htcondor-ce) issues with jobs
+-   **Debugging tools:** HTCondor-CE offers [many tools to help troubleshoot](/compute-element/troubleshoot-htcondor-ce)
+    issues with jobs
 -   **Routing as configuration:** HTCondor-CE’s mechanism to transform and submit jobs is customized via configuration
     variables, which means that customizations will persist across upgrades and will not involve modification of
     software internals to route jobs
@@ -60,8 +61,9 @@ The hosted HTCondor-CE is a special configuration of HTCondor-CE that can submit
 It provides a simple starting point for opportunistic resource owners that want to start contributing to the OSG with
 minimal effort: an organization will be able to accept OSG jobs by allowing SSH access to a submit node in their cluster.
 
-If your site intends to run thousands of OSG jobs, you will need to host a standard [HTCondor-CE](install-htcondor-ce)
-because the hosted HTCondor-CE has not yet been optimized for such loads.
+If your site intends to run thousands of OSG jobs, you will need to host a standard
+[HTCondor-CE](/compute-element/install-htcondor-ce) because the hosted HTCondor-CE has not yet been optimized for such
+loads.
 
 To discuss using a hosted SSH HTCondor-CE, contact OSG User Support at
 [user-support@opensciencegrid.org](mailto:user-support@opensciencegrid.org)
@@ -109,14 +111,14 @@ directory must be exported to a shared file system that is mounted on the batch 
 How the CE is Customized
 ------------------------
 
-Aside from the [basic configuration](install-htcondor-ce#configuring-htcondor-ce) required in the CE installation, there
-are two main ways to customize your CE (if you decide any customization is required at all):
+Aside from the [basic configuration](/compute-element/install-htcondor-ce#configuring-htcondor-ce) required in the CE
+installation, there are two main ways to customize your CE (if you decide any customization is required at all):
 
 -   **Deciding which VOs are allowed to run at your site:** The recommended method of authorizing VOs at your site is
     based on the [LCMAPS framework](/security/lcmaps-voms-authentication)
 -   **How to filter and transform the grid jobs to be run on your batch system:** Filtering and transforming grid jobs
     (i.e., setting site-specific attributes or resource limits), requires configuration of your site’s job routes.
-    For examples of common job routes, consult the [JobRouter recipes](job-router-recipes) page.
+    For examples of common job routes, consult the [JobRouter recipes](/compute-element/job-router-recipes) page.
 
 !!! note
     If you are running HTCondor as your batch system, you will have two HTCondor configurations side-by-side (one
@@ -144,8 +146,8 @@ Next steps
 
 Once the basic installation is done, additional activities include:
 
--   [Setting up job routes to customize incoming jobs](job-router-recipes)
--   [Submitting jobs to a HTCondor-CE](submit-htcondor-ce) 
--   [Troubleshooting the HTCondor-CE](troubleshoot-htcondor-ce) 
+-   [Setting up job routes to customize incoming jobs](/compute-element/job-router-recipes)
+-   [Submitting jobs to a HTCondor-CE](/compute-element/submit-htcondor-ce) 
+-   [Troubleshooting the HTCondor-CE](/compute/element/troubleshoot-htcondor-ce) 
 -   Register the CE with OIM
 -   Register with the OSG GlideinWMS factories and/or the ATLAS AutoPyFactory

--- a/docs/compute-element/htcondor-ce-overview.md
+++ b/docs/compute-element/htcondor-ce-overview.md
@@ -5,46 +5,75 @@ This document serves as an introduction to HTCondor-CE and how it works.
 Before continuing with the overview, make sure that you are familiar with the following concepts:
 
 -   An OSG site plan
-    -   What is a batch system and which one will you use ([HTCondor](http://htcondor.org/), PBS, LSF, SGE, or [SLURM](https://slurm.schedmd.com/))?
-    -   Security in the OSG via [GSI](http://toolkit.globus.org/toolkit/docs/3.2/security.html) (i.e., [Certificate authorities](https://en.wikipedia.org/wiki/Certificate_authority), user and host [certificates](https://en.wikipedia.org/wiki/Public_key_certificate), proxies)
--   Pilot jobs, frontends, and factories (i.e., [GlideinWMS](http://glideinwms.fnal.gov/doc.prd/index.html), AutoPyFactory)
+    -   What is a batch system and which one will you use ([HTCondor](http://htcondor.org/), PBS, LSF, SGE, or
+        [SLURM](https://slurm.schedmd.com/))?
+    -   Security in the OSG via [GSI](http://toolkit.globus.org/toolkit/docs/3.2/security.html) (i.e.,
+        [Certificate authorities](https://en.wikipedia.org/wiki/Certificate_authority), user and host
+        [certificates](https://en.wikipedia.org/wiki/Public_key_certificate), proxies)
+-   Pilot jobs, frontends, and factories (i.e., [GlideinWMS](http://glideinwms.fnal.gov/doc.prd/index.html),
+    AutoPyFactory)
 
 What is a Compute Element?
 --------------------------
 
-An OSG Compute Element (CE) is the entry point for the OSG to your local resources: a layer of software that you install on a machine that can submit jobs into your local batch system. At the heart of the CE is the *job gateway* software, which is responsible for handling incoming jobs, authenticating and authorizing them, and delegating them to your batch system for execution.
+An OSG Compute Element (CE) is the entry point for the OSG to your local resources: a layer of software that you install
+on a machine that can submit jobs into your local batch system.
+At the heart of the CE is the *job gateway* software, which is responsible for handling incoming jobs, authenticating
+and authorizing them, and delegating them to your batch system for execution.
 
-Today in the OSG, most jobs that arrive at a CE (called *grid jobs*) are **not** end-user jobs, but rather pilot jobs submitted from factories. Successful pilot jobs create and make available an environment for actual end-user jobs to match and ultimately run within the pilot job container. Eventually pilot jobs remove themselves, typically after a period of inactivity.
+Today in the OSG, most jobs that arrive at a CE (called *grid jobs*) are **not** end-user jobs, but rather pilot jobs
+submitted from factories.
+Successful pilot jobs create and make available an environment for actual end-user jobs to match and ultimately run
+within the pilot job container.
+Eventually pilot jobs remove themselves, typically after a period of inactivity.
 
 What is HTCondor-CE?
 --------------------
 
-HTCondor-CE is a special configuration of the HTCondor software designed to be a job gateway solution for the OSG. It is configured to use the [JobRouter daemon](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html) to delegate jobs by transforming and submitting them to the site’s batch system.
+HTCondor-CE is a special configuration of the HTCondor software designed to be a job gateway solution for the OSG.
+It is configured to use the [JobRouter daemon](http://research.cs.wisc.edu/htcondor/manual/v8.6/5_4HTCondor_Job.html) to
+delegate jobs by transforming and submitting them to the site’s batch system.
 
 Benefits of running the HTCondor-CE:
 
 -   **Scalability:** HTCondor-CE is capable of supporting job workloads of large sites
 -   **Debugging tools:** HTCondor-CE offers [many tools to help troubleshoot](troubleshoot-htcondor-ce) issues with jobs
--   **Routing as configuration:** HTCondor-CE’s mechanism to transform and submit jobs is customized via configuration variables, which means that customizations will persist across upgrades and will not involve modification of software internals to route jobs
+-   **Routing as configuration:** HTCondor-CE’s mechanism to transform and submit jobs is customized via configuration
+    variables, which means that customizations will persist across upgrades and will not involve modification of
+    software internals to route jobs
 
 How Jobs Run
 ------------
 
-Once an incoming grid job is authorized, it is placed into HTCondor-CE’s scheduler where the JobRouter creates a transformed copy (called the *routed job*) and submits the copy to the batch system (called the *batch system job*). After submission, HTCondor-CE monitors the batch system job and communicates its status to the original grid job, which in turn notifies the original submitter (e.g., job factory) of any updates. When the job completes, files are transferred along the same chain: from the batch system to the CE, then from the CE to the original submitter.
+Once an incoming grid job is authorized, it is placed into HTCondor-CE’s scheduler where the JobRouter creates a
+transformed copy (called the *routed job*) and submits the copy to the batch system (called the *batch system job*).
+After submission, HTCondor-CE monitors the batch system job and communicates its status to the original grid job, which
+in turn notifies the original submitter (e.g., job factory) of any updates.
+When the job completes, files are transferred along the same chain: from the batch system to the CE, then from the CE to
+the original submitter.
 
 ### Hosted HTCondor-CE over SSH
 
-The hosted HTCondor-CE is intended for small sites or as an introduction to the OSG. The OSG configures and maintains the HTCondor-CE on behalf of the site.  The hosted HTCondor-CE is a special configuration of HTCondor-CE that can submit jobs to a remote cluster over SSH. It provides a simple starting point for opportunistic resource owners that want to start contributing to the OSG with minimal effort: an organization will be able to accept OSG jobs by allowing SSH access to a submit node in their cluster.
+The hosted HTCondor-CE is intended for small sites or as an introduction to the OSG.
+The OSG configures and maintains the HTCondor-CE on behalf of the site.
+The hosted HTCondor-CE is a special configuration of HTCondor-CE that can submit jobs to a remote cluster over SSH.
+It provides a simple starting point for opportunistic resource owners that want to start contributing to the OSG with
+minimal effort: an organization will be able to accept OSG jobs by allowing SSH access to a submit node in their cluster.
 
-If your site intends to run thousands of OSG jobs, you will need to host a standard [HTCondor-CE](install-htcondor-ce) because the hosted HTCondor-CE has not yet been optimized for such loads.
+If your site intends to run thousands of OSG jobs, you will need to host a standard [HTCondor-CE](install-htcondor-ce)
+because the hosted HTCondor-CE has not yet been optimized for such loads.
 
-To discuss using a hosted SSH HTCondor-CE, contact OSG User Support at [user-support@opensciencegrid.org](mailto:user-support@opensciencegrid.org)
+To discuss using a hosted SSH HTCondor-CE, contact OSG User Support at
+[user-support@opensciencegrid.org](mailto:user-support@opensciencegrid.org)
 
 ![HTCondor-CE-Bosco](/img/HTCondorCEBosco.png)
 
 ### On HTCondor batch systems
 
-For a site with an HTCondor **batch system**, the JobRouter can use HTCondor protocols to place a transformed copy of the grid job directly into the batch system’s scheduler, meaning that the routed and batch system jobs are one and the same. Thus, there are three representations of your job, each with its own ID (see diagram below):
+For a site with an HTCondor **batch system**, the JobRouter can use HTCondor protocols to place a transformed copy of
+the grid job directly into the batch system’s scheduler, meaning that the routed and batch system jobs are one and the
+same.
+Thus, there are three representations of your job, each with its own ID (see diagram below):
 
 -   Submit host: the HTCondor job ID in the original queue
 -   HTCondor-CE: the incoming grid job’s ID
@@ -52,14 +81,19 @@ For a site with an HTCondor **batch system**, the JobRouter can use HTCondor pro
 
 ![HTCondor-CE with an HTCondor batch system](/img/ce_condorbatchsystem.png)
 
-In an HTCondor-CE/HTCondor setup, files are transferred from HTCondor-CE’s spool directory to the batch system’s spool directory using internal HTCondor protocols.
+In an HTCondor-CE/HTCondor setup, files are transferred from HTCondor-CE’s spool directory to the batch system’s spool
+directory using internal HTCondor protocols.
 
 !!! note
-    The JobRouter copies the job directly into the batch system and does not make use of `condor_submit`. This means that if the HTCondor batch system is configured to add attributes to incoming jobs when they are submitted (i.e., `SUBMIT_EXPRS`), these attributes will not be added to the routed jobs.
+    The JobRouter copies the job directly into the batch system and does not make use of `condor_submit`.
+    This means that if the HTCondor batch system is configured to add attributes to incoming jobs when they are
+    submitted (i.e., `SUBMIT_EXPRS`), these attributes will not be added to the routed jobs.
 
 ### On other batch systems
 
-For non-HTCondor batch systems, the JobRouter transforms the grid job into a routed job on the CE and the routed job submits a job into the batch system via a process called the BLAHP. Thus, there are four representations of your job, each with its own ID (see diagram below):
+For non-HTCondor batch systems, the JobRouter transforms the grid job into a routed job on the CE and the routed job
+submits a job into the batch system via a process called the BLAHP.
+Thus, there are four representations of your job, each with its own ID (see diagram below):
 
 -   Submit host: the HTCondor job ID in the original queue
 -   HTCondor-CE: the incoming grid job’s ID and the routed job’s ID
@@ -69,28 +103,41 @@ Although the following figure specifies the PBS case, it applies to all non-HTCo
 
 ![HTCondor-CE with other batch systems](/img/ce_otherbatchsystem.png)
 
-With non-HTCondor batch systems, HTCondor-CE cannot use internal HTCondor protocols to transfer files so its spool directory must be exported to a shared file system that is mounted on the batch system’s worker nodes.
-
-
+With non-HTCondor batch systems, HTCondor-CE cannot use internal HTCondor protocols to transfer files so its spool
+directory must be exported to a shared file system that is mounted on the batch system’s worker nodes.
 
 How the CE is Customized
 ------------------------
 
-Aside from the [basic configuration](install-htcondor-ce#configuring-htcondor-ce) required in the CE installation, there are two main ways to customize your CE (if you decide any customization is required at all):
+Aside from the [basic configuration](install-htcondor-ce#configuring-htcondor-ce) required in the CE installation, there
+are two main ways to customize your CE (if you decide any customization is required at all):
 
 -   **Deciding which VOs are allowed to run at your site:** The recommended method of authorizing VOs at your site is
     based on the [LCMAPS framework](/security/lcmaps-voms-authentication)
--   **How to filter and transform the grid jobs to be run on your batch system:** Filtering and transforming grid jobs (i.e., setting site-specific attributes or resource limits), requires configuration of your site’s job routes. For examples of common job routes, consult the [JobRouter recipes](job-router-recipes) page.
+-   **How to filter and transform the grid jobs to be run on your batch system:** Filtering and transforming grid jobs
+    (i.e., setting site-specific attributes or resource limits), requires configuration of your site’s job routes.
+    For examples of common job routes, consult the [JobRouter recipes](job-router-recipes) page.
 
 !!! note
-    If you are running HTCondor as your batch system, you will have two HTCondor configurations side-by-side (one residing in `/etc/condor/` and the other in `/etc/condor-ce`) and will need to make sure to differentiate the two when editing any configuration.
+    If you are running HTCondor as your batch system, you will have two HTCondor configurations side-by-side (one
+    residing in `/etc/condor/` and the other in `/etc/condor-ce`) and will need to make sure to differentiate the two
+    when editing any configuration.
 
 How Security Works
 ------------------
 
-In the OSG, security depends on a PKI infrastructure involving Certificate Authorities (CAs) where CAs sign and issue certificates. When these clients and hosts wish to communicate with each other, the identities of each party is confirmed by cross-checking their certificates with the signing CA and establishing trust.
+In the OSG, security depends on a PKI infrastructure involving Certificate Authorities (CAs) where CAs sign and issue
+certificates.
+When these clients and hosts wish to communicate with each other, the identities of each party is confirmed by
+cross-checking their certificates with the signing CA and establishing trust.
 
-In its default configuration, HTCondor-CE uses GSI-based authentication and authorization to verify the certificate chain, which will work with [LCMAPS VOMS authentication](/security/lcmaps-voms-authentication), existing GUMS servers, or grid mapfiles. Additionally, it can be reconfigured to provide alternate authentication mechanisms such as Kerberos, SSL, shared secret, or even IP-based authentication. More information about authorization methods can be found [here](http://research.cs.wisc.edu/htcondor/manual/v8.6/3_8Security.html#SECTION00483000000000000000).
+In its default configuration, HTCondor-CE uses GSI-based authentication and authorization to verify the certificate
+chain, which will work with [LCMAPS VOMS authentication](/security/lcmaps-voms-authentication), existing GUMS servers,
+or grid mapfiles.
+Additionally, it can be reconfigured to provide alternate authentication mechanisms such as Kerberos, SSL, shared
+secret, or even IP-based authentication.
+More information about authorization methods can be found
+[here](http://research.cs.wisc.edu/htcondor/manual/v8.6/3_8Security.html#SECTION00483000000000000000).
 
 Next steps
 ----------

--- a/docs/compute-element/htcondor-ce-overview.md
+++ b/docs/compute-element/htcondor-ce-overview.md
@@ -66,7 +66,7 @@ If your site intends to run thousands of OSG jobs, you will need to host a stand
 loads.
 
 To discuss using a hosted SSH HTCondor-CE, contact OSG User Support at
-[user-support@opensciencegrid.org](mailto:user-support@opensciencegrid.org)
+[user-support@opensciencegrid.org](mailto:user-support@opensciencegrid.org).
 
 ![HTCondor-CE-Bosco](/img/HTCondorCEBosco.png)
 
@@ -134,8 +134,7 @@ When these clients and hosts wish to communicate with each other, the identities
 cross-checking their certificates with the signing CA and establishing trust.
 
 In its default configuration, HTCondor-CE uses GSI-based authentication and authorization to verify the certificate
-chain, which will work with [LCMAPS VOMS authentication](/security/lcmaps-voms-authentication), existing GUMS servers,
-or grid mapfiles.
+chain, which will work with [LCMAPS VOMS authentication](/security/lcmaps-voms-authentication).
 Additionally, it can be reconfigured to provide alternate authentication mechanisms such as Kerberos, SSL, shared
 secret, or even IP-based authentication.
 More information about authorization methods can be found

--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -325,6 +325,9 @@ Validating HTCondor-CE
 
 To validate an HTCondor-CE, perform the following verification steps:
 
+1. Verify that all the necessary daemons are running with
+   [condor\_ce\_status](/compute-element/troubleshoot-htcondor-ce#condor_ce_status).
+
 1. Verify the CE's network configuration using [condor\_ce\_host\_network\_check](troubleshoot-htcondor-ce#condor_ce_host_network_check).
 
 1. Verify that jobs can complete successfully using [condor\_ce\_trace](troubleshoot-htcondor-ce#condor_ce_trace).

--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -328,9 +328,11 @@ To validate an HTCondor-CE, perform the following verification steps:
 1. Verify that all the necessary daemons are running with
    [condor\_ce\_status](/compute-element/troubleshoot-htcondor-ce#condor_ce_status).
 
-1. Verify the CE's network configuration using [condor\_ce\_host\_network\_check](troubleshoot-htcondor-ce#condor_ce_host_network_check).
+1. Verify the CE's network configuration using
+   [condor\_ce\_host\_network\_check](/compute-element/troubleshoot-htcondor-ce#condor_ce_host_network_check).
 
-1. Verify that jobs can complete successfully using [condor\_ce\_trace](troubleshoot-htcondor-ce#condor_ce_trace).
+1. Verify that jobs can complete successfully using
+   [condor\_ce\_trace](/compute-element/troubleshoot-htcondor-ce#condor_ce_trace).
 
 Troubleshooting HTCondor-CE
 ---------------------------

--- a/docs/compute-element/troubleshoot-htcondor-ce.md
+++ b/docs/compute-element/troubleshoot-htcondor-ce.md
@@ -719,29 +719,32 @@ manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/condor_router_q.html)
 
 #### Usage
 
-To see the daemons running on a CE, you can run the following:
+To see the daemons running on a CE, run the following command:
 
 ``` console
-user@host $ condor_ce_status -any -name condorce.example.com -pool condorce.example.com:9619
+user@host $ condor_ce_status -any
 ```
 
-Replacing `condorce.example.com`  with the hostname of the CE.
+`condor_ce_status` takes the same arguments as `condor_status`, which are documented in the
+[HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/condor_status.html).
 
-!!! note
-    If you run the `condor_ce_status` command on the CE that you are testing, omit the `-name` and `-pool` options. `condor_ce_status` takes the same arguments as `condor_status` and is documented in the [HTCondor manual](http://research.cs.wisc.edu/htcondor/manual/v8.6/condor_status.html).
+!!! note ""Missing" Worker Nodes"
+    An HTCondor-CE will not show any worker nodes (e.g. `Machine` entries in the `condor_ce_status -any` output) if
+    it does not have any running GlideinWMS pilot jobs.
+    This is expected since HTCondor-CE only forwards incoming grid jobs to your batch system and does not match jobs to
+    worker nodes.
 
 #### Troubleshooting
 
-To list the daemons that are configured to run:
+If the output of `condor_ce_status -any` does not show at least the following daemons:
 
-``` console
-user@host $ condor_ce_config_val -v DAEMON_LIST
-DAEMON_LIST: MASTER COLLECTOR SCHEDD JOB_ROUTER, SHARED_PORT, SHARED_PORT
-  Defined in '/etc/condor-ce/config.d/03-ce-shared-port.conf', line 9.
-```
+- Collector
+- Scheduler
+- DaemonMaster
+- Job_Router
 
-If you do not see these daemons in the output of `condor_ce_status`, check the [Master log](#masterlog) for errors.
-
+Increase the [debug level](/compute-element/troubleshoot-htcondor-ce/#htcondor-ce-troubleshooting-items) and consult the
+[HTCondor-CE logs](/compute-element/troubleshoot-htcondor-ce/#htcondor-ce-troubleshooting-data) for errors.
 
 ### condor_ce_config_val
 


### PR DESCRIPTION
- The bit about missing worker nodes came up in [this GGUS ticket](https://ggus.eu/index.php?mode=ticket_info&ticket_id=134756).
- Some formatting fixes for the CE overview doc. 
- I was toying with the idea of expanding on `At the heart of the CE is...delegating them to your batch system for execution.` in the CE overview doc to emphasize that CEs don't implement site policy but I couldn't come up with anything good for it.