### PR TITLE
Clarify round-robin DNS registration

### DIFF
--- a/docs/data/frontier-squid.md
+++ b/docs/data/frontier-squid.md
@@ -152,17 +152,17 @@ To register your Frontier Squid host, follow the general registration instructio
 
         :::console
         ...
-        FQDN: fully.qualified.DNS.name.of.your.server
+        FQDN: <FULLY QUALIFIED DOMAIN NAME>
         Services:
           Squid:
             Description: Generic squid service
         ...
 
+    Replacing `<FULLY QUALIFIED DOMAIN NAME>` with your Frontier Squid server's DNS entry or in the case of multiple
+    Frontier Squid servers for a single resource, the round-robin DNS entry.
+
     See the [BNL_ATLAS_Frontier_Squid](https://github.com/opensciencegrid/topology/blob/master/topology/Brookhaven%20National%20Laboratory/Brookhaven%20ATLAS%20Tier1/BNL-ATLAS.yaml#L306-L325) 
     for a complete example.
-
-    For a resource served by multiple Frontier Squid servers, we recommend setting up a round-robin DNS entry and using
-    it for the FQDN field in your registration.
 
 2.  If you are setting up a new resource, set `Active: false`.
     Only set `Active: true` for a resource when it is accepting requests and ready for production.

--- a/docs/data/frontier-squid.md
+++ b/docs/data/frontier-squid.md
@@ -160,18 +160,8 @@ To register your Frontier Squid host, follow the general registration instructio
 
     See the [BNL-ATLAS](https://github.com/opensciencegrid/topology/blob/master/topology/Brookhaven%20National%20Laboratory/Brookhaven%20ATLAS%20Tier1/BNL-ATLAS.yaml) Squid resource for a complete example.
 
-    If you have more than one server providing the same squid service,
-    it is best to register them with one FQDN that is a round-robin DNS
-    entry listing all the squids, instead of registering them separately.
-    For example:
-
-        :::console
-        ...
-        FQDN: fully.qualified.DNS.name.of.your.server
-        FQDNAliases:
-          - second.fully.qualified.DNS.name.of.your.server
-          - third.fully.qualified.DNS.name.of.your.server
-        ...
+    For a resource served by multiple Frontier Squid servers, we recommend setting up a round-robin DNS entry and using
+    it for the FQDN field in your registration.
 
 2.  If you are setting up a new resource, set `Active: false`.
     Only set `Active: true` for a resource when it is accepting requests and ready for production.

--- a/docs/data/frontier-squid.md
+++ b/docs/data/frontier-squid.md
@@ -158,7 +158,8 @@ To register your Frontier Squid host, follow the general registration instructio
             Description: Generic squid service
         ...
 
-    See the [BNL-ATLAS](https://github.com/opensciencegrid/topology/blob/master/topology/Brookhaven%20National%20Laboratory/Brookhaven%20ATLAS%20Tier1/BNL-ATLAS.yaml) Squid resource for a complete example.
+    See the [BNL_ATLAS_Frontier_Squid](https://github.com/opensciencegrid/topology/blob/master/topology/Brookhaven%20National%20Laboratory/Brookhaven%20ATLAS%20Tier1/BNL-ATLAS.yaml#L306-L325) 
+    for a complete example.
 
     For a resource served by multiple Frontier Squid servers, we recommend setting up a round-robin DNS entry and using
     it for the FQDN field in your registration.


### PR DESCRIPTION
I think this improves on the previous text by not overloading the word "registration"