### PR TITLE
Change D_FULLDEBUG to D_ALWAYS:2

### DIFF
--- a/docs/compute-element/job-router-recipes.md
+++ b/docs/compute-element/job-router-recipes.md
@@ -383,7 +383,7 @@ JOB_ROUTER_ENTRIES = [ \
 To help debug expressions in your routes, you can use the `debug()` function. First, set the debug mode for the JobRouter by editing a file in `/etc/condor-ce/config.d/` to read
 
 ```
-JOB_ROUTER_DEBUG = D_FULLDEBUG
+JOB_ROUTER_DEBUG = D_ALWAYS:2 D_CAT
 ```
 
 Then wrap the problematic attribute in `debug()`:

--- a/docs/compute-element/troubleshoot-htcondor-ce.md
+++ b/docs/compute-element/troubleshoot-htcondor-ce.md
@@ -81,7 +81,7 @@ Before troubleshooting, we recommend increasing the log level:
 
 1.  Write the following into `/etc/condor-ce/config.d/99-local.conf` to increase the log level for all daemons:
 
-        ALL_DEBUG = D_FULLDEBUG D_CAT
+        ALL_DEBUG = D_ALWAYS:2 D_CAT
 
 2.  Ensure that the configuration is in place:
 
@@ -548,8 +548,8 @@ Authorized:                  TRUE
 
 1.  **If you see “ERROR: couldn’t locate (null)”**, that means the HTCondor-CE schedd (the daemon that schedules jobs) cannot be reached. To track down the issue, increase debugging levels on the CE:
 
-        MASTER_DEBUG = D_FULLDEBUG D_CAT
-        SCHEDD_DEBUG = D_FULLDEBUG D_CAT
+        MASTER_DEBUG = D_ALWAYS:2 D_CAT
+        SCHEDD_DEBUG = D_ALWAYS:2 D_CAT
 
     Then look in the [MasterLog](#masterlog) and [SchedLog](#schedlog) for any errors.
 
@@ -581,8 +581,8 @@ If the jobs that you are submiting to a CE are not completing, `condor_ce_q` can
 
 1.  **If the schedd is not running:** You will see a lengthy message about being unable to contact the schedd. To track down the issue, increase the debugging levels on the CE with:
 
-        MASTER_DEBUG = D_FULLDEBUG D_CAT
-        SCHEDD_DEBUG = D_FULLDEBUG D_CAT
+        MASTER_DEBUG = D_ALWAYS:2 D_CAT
+        SCHEDD_DEBUG = D_ALWAYS:2 D_CAT
 
     To apply these changes, reconfigure HTCondor-CE:
 
@@ -829,7 +829,7 @@ they fail to start.
 - Increasing the debug level:
     1. Set the following value in `/etc/condor-ce/config.d/99-local.conf` on the CE host:
 
-            MASTER_DEBUG = D_FULLDEBUG D_CAT
+            MASTER_DEBUG = D_ALWAYS:2 D_CAT
 
     2. To apply these changes, reconfigure HTCondor-CE:
 
@@ -857,7 +857,7 @@ It contains valuable information when trying to troubleshoot authentication issu
 - Increasing the debug level:
     1. Set the following value in `/etc/condor-ce/config.d/99-local.conf` on the CE host:
 
-            SCHEDD_DEBUG = D_FULLDEBUG D_CAT
+            SCHEDD_DEBUG = D_ALWAYS:2 D_CAT
 
     2. To apply these changes, reconfigure HTCondor-CE:
 
@@ -934,7 +934,7 @@ troubleshoot issues with job routing.
 - Increasing the debug level:
     1. Set the following value in `/etc/condor-ce/config.d/99-local.conf` on the CE host:
 
-            JOB_ROUTER_DEBUG = D_FULLDEBUG D_CAT
+            JOB_ROUTER_DEBUG = D_ALWAYS:2 D_CAT
 
     2. Apply these changes, reconfigure HTCondor-CE:
 
@@ -943,7 +943,7 @@ troubleshoot issues with job routing.
 
 #### Known Errors ####
 
--   If you have `D_FULLDEBUG` turned on for the job router, you will see errors like the following:
+-   If you have `D_ALWAYS:2` turned on for the job router, you will see errors like the following:
 
         06/12/15 14:00:28 HOOK_UPDATE_JOB_INFO not configured.
 
@@ -992,7 +992,7 @@ Wiki](https://htcondor-wiki.cs.wisc.edu/index.cgi/wiki?p=GridmanagerLog).
 
             MAX_GRIDMANAGER_LOG = 6h
             MAX_NUM_GRIDMANAGER_LOG = 8
-            GRIDMANAGER_DEBUG = D_FULLDEBUG D_CAT
+            GRIDMANAGER_DEBUG = D_ALWAYS:2 D_CAT
 
     2. To apply these changes, reconfigure HTCondor-CE:
 
@@ -1044,7 +1044,7 @@ This log is a good place to check if experiencing connectivity issues with HTCon
 - Increasing the debug level:
     1. Set the following value in `/etc/condor-ce/config.d/99-local.conf` on the CE host:
 
-            SHARED_PORT_DEBUG = D_FULLDEBUG D_CAT
+            SHARED_PORT_DEBUG = D_ALWAYS:2 D_CAT
 
     2. To apply these changes, reconfigure HTCondor-CE:
 


### PR DESCRIPTION
The latter does the same thing but more safely (i.e., not as a
verbosity modifier for other debug messages). Recommended by TJ.