### PR TITLE
Cleanup GUMS references

### DIFF
--- a/docs/compute-element/troubleshoot-htcondor-ce.md
+++ b/docs/compute-element/troubleshoot-htcondor-ce.md
@@ -149,7 +149,8 @@ You may see error messages like the following in your [SchedLog](#schedlog):
 
 **Next actions**
 
-1.  **Check GUMS or grid-mapfile** and ensure that the user's DN is known to your [authentication method](install-htcondor-ce#configuring-authentication)
+1.  **Check voms-mapfile or grid-mapfile** and ensure that the user's DN or VOMS attributes are known to your
+    [authentication method](install-htcondor-ce#configuring-authentication)
 2.  **Check for lcmaps errors** in `/var/log/messages`
 3.  **If you do not see helpful error messages in `/var/log/messages`,** adjust the debug level by adding `export LCMAPS_DEBUG_LEVEL=5` to `/etc/sysconfig/condor-ce`, restarting the condor-ce service, and checking `/var/log/messages` for errors again.
 
@@ -265,7 +266,7 @@ ERROR: couldn't locate condorce.example.com!
 
 #### Remote idle jobs: Are you authorized to run jobs on the CE?
 
-The CE will only accept jobs from users that authenticate via LCMAPS, grid mapfile, or GUMS. 
+The CE will only accept jobs from users that authenticate via [LCMAPS VOMS](/security/lcmaps-voms-authentication).
 You can use [condor\_ce\_ping](#condor_ce_ping) to check if you are authorized and what user your proxy is being mapped
 to.
 

--- a/docs/data/install-hadoop.md
+++ b/docs/data/install-hadoop.md
@@ -393,7 +393,6 @@ Here are the most relevant file and directory locations:
 | Probe Executables   | No             | /usr/share/gratia/gridftp-transfer       |
 | Log files           | No             | /var/log/gratia                          |
 | Temporary files     | No             | /var/lib/gratia/tmp                      |
-| Gums configuration  | Yes            | /etc/gums/gums-client.properties         |
 
 The RPM installs the Gratia probe into the system crontab, but does not configure it. The configuration of the probe is controlled by the file
 
@@ -967,7 +966,7 @@ The standalone server runs on port 5002, handles a single GridFTP request, and w
 | GridFTP| runtime config files                         | `/etc/gridftp-hdfs/*`, `/etc/sysconfig/gridftp-hdfs`                  | Maybe                                               |
 | GridFTP| System binaries                              | `/usr/bin/gridftp-hdfs-standalone`, `/usr/sbin/globus-gridftp-server` | No                                                  |
 | GridFTP| System libraries                             | `/usr/lib64/libglobus_gridftp_server_hdfs.so*`                        | No                                                  |
-| GridFTP| GUMS client (called by LCMAPS) configuration | `/etc/lcmaps.db`                                                      | Yes                                                 |
+| GridFTP| LCMAPS VOMS configuration                    | `/etc/lcmaps.db`                                                      | Yes                                                 |
 | GridFTP| CA certificates                              | `/etc/grid-security/certificates/*`                                   | No                                                  |
 
 | Service/Process | Configuration File               | Description                                                                                     |

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -63,7 +63,7 @@ The LCMAPS VOMS plugin does not work with gLExec.
 
 ### Supporting mapped VOs and users
 
-Unix accounts must exist for each VO, VO role, VO group, or user you choose to support in the [mapfiles](#configuration-files):
+ Ensure Unix accounts exist for each VO, VO role, VO group, or user you choose to support in the [mapfiles](#configuration-files):
 
 1.  Consult the default VO mappings in `/usr/share/osg/voms-mapfile-default` to determine the mapped Unix account names.
     Each of the mapfiles has the following format:

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -1,11 +1,20 @@
 Installing and Maintaining the LCMAPS VOMS Plugin
 =================================================
 
-LCMAPS is a software library used on [HTCondor-CE](/compute-element/install-htcondor-ce), [GridFTP](/data/gridftp), and [XRootD](/data/xrootd/install-storage-element) hosts for mapping grid certificates of incoming connections to specific Unix accounts. The LCMAPS VOMS plugin enables LCMAPS to make mapping decisions based on the VOMS attributes of grid certificates, e.g., `/cms/Role=production/Capability=NULL`. In OSG 3.4, the LCMAPS VOMS plugin replaced GUMS and edg-mkgridmap as the authentication method at OSG sites.
+LCMAPS is a software library used on [HTCondor-CE](/compute-element/install-htcondor-ce), [GridFTP](/data/gridftp), and
+[XRootD](/data/xrootd/install-storage-element) hosts for mapping grid certificates of incoming connections to specific
+Unix accounts.
+The LCMAPS VOMS plugin enables LCMAPS to make mapping decisions based on the VOMS attributes of grid certificates, e.g.
+`/cms/Role=production/Capability=NULL`.
+In OSG 3.4, the LCMAPS VOMS plugin replaced GUMS and edg-mkgridmap as the authentication method at OSG sites.
 
-The OSG provides a default set of mappings from VOMS attributes to Unix accounts. By configuring LCMAPS, you can override these mappings, including changing the Unix account that a VO is mapped to, banning based on VOMS attributes, banning a specific user, or adding a VO, VO group, VO role, and/or user that is not in the OSG's set of mappings.
+The OSG provides a default set of mappings from VOMS attributes to Unix accounts.
+By configuring LCMAPS, you can override these mappings, including changing the Unix account that a VO is mapped to,
+banning based on VOMS attributes, banning a specific user, or adding a VO, VO group, VO role, and/or user that is not in
+the OSG's set of mappings.
 
-Use this page to learn how to install and configure the LCMAPS VOMS plugin to authenticate users to access your resources on a per-VO basis.
+Use this page to learn how to install and configure the LCMAPS VOMS plugin to authenticate users to access your
+resources on a per-VO basis.
 
 
 Installing the LCMAPS VOMS Plugin
@@ -41,7 +50,8 @@ the default mappings, or migrate from edg-mkgridmap or GUMS.
 
 ### Enabling the LCMAPS VOMS plugin
 
-To configure your host to use LCMAPS VOMS plugin authentication, edit `/etc/osg/config.d/10-misc.ini` and set the following options:
+To configure your host to use LCMAPS VOMS plugin authentication, edit `/etc/osg/config.d/10-misc.ini` and set the
+following options:
 
 ``` ini
 edit_lcmaps_db = True
@@ -55,7 +65,8 @@ The LCMAPS VOMS plugin does not work with gLExec.
 
 Unix accounts must exist for each VO, VO role, VO group, or user you choose to support in the [mapfiles](#configuration-files):
 
-1.  Consult the default VO mappings in `/usr/share/osg/voms-mapfile-default` to determine the mapped Unix account names. Each of the mapfiles has the following format:
+1.  Consult the default VO mappings in `/usr/share/osg/voms-mapfile-default` to determine the mapped Unix account names.
+    Each of the mapfiles has the following format:
 
         "%RED%<VO, VO role, VO group or user>%ENDCOLOR%" %RED%<Unix account>%ENDCOLOR%
 
@@ -78,19 +89,25 @@ Unix accounts must exist for each VO, VO role, VO group, or user you choose to s
     Additionally, it is also recommended to create the `mis` Unix account,
     which is used by OSG staff to assist with troubleshooting.
 
-1.  Edit `/etc/osg/config.d/30-gip.ini` and specify the supported VOs per [Subcluster or ResourceEntry section](../other/configuration-with-osg-configure#subcluster-resource-entry):
+1.  Edit `/etc/osg/config.d/30-gip.ini` and specify the supported VOs per [Subcluster or ResourceEntry section](/other/configuration-with-osg-configure#subcluster-resource-entry):
 
         :::ini
         allowed_vos="VO1,VO2..."
 
 ### Applying configuration settings
 
-Making changes to the OSG configuration files in the `/etc/osg/config.d` directory does not apply those settings to software automatically. For the OSG settings, use the [osg-configure](../other/configuration-with-osg-configure) tool to validate (to a limited extent) and apply the settings to the relevant software components. If instead you wish to manage the LCMAPS VOMS plugin configuration yourself, skip to the [manual configuration section](#manual-configuration).
+Making changes to the OSG configuration files in the `/etc/osg/config.d` directory does not apply those settings to
+software automatically.
+For the OSG settings, use the [osg-configure](/other/configuration-with-osg-configure) tool to validate (to a limited
+extent) and apply the settings to the relevant software components.
+If instead you wish to manage the LCMAPS VOMS plugin configuration yourself, skip to the
+[manual configuration section](#manual-configuration).
 
 1.  Make all changes to `.ini` files in the `/etc/osg/config.d` directory.
 
     !!!note
-        This document only describes the critical settings for the LCMAPS VOMS plugin and related software. You may need to configure other software that is installed on your host, too.
+        This document only describes the critical settings for the LCMAPS VOMS plugin and related software.
+        You may need to configure other software that is installed on your host, too.
 
 1.  Validate the configuration settings:
 
@@ -106,7 +123,9 @@ Making changes to the OSG configuration files in the `/etc/osg/config.d` directo
 
 ### Optional configuration
 
-The following subsections contain information on migration from `edg-mkgridmap`, mapping or banning users by their certificates' Distinguished Names (DNs) or by their proxies' VOMS attributes. Any optional configuration is to be performed after the installation and configuration sections above.
+The following subsections contain information on migration from `edg-mkgridmap`, mapping or banning users by their
+certificates' Distinguished Names (DNs) or by their proxies' VOMS attributes.
+Any optional configuration is to be performed after the installation and configuration sections above.
 
 For a table of the configuration files and their order of evaluation, consult the [reference section](#configuration-files).
 
@@ -121,7 +140,10 @@ For a table of the configuration files and their order of evaluation, consult th
 
 #### Migrating from edg-mkgridmap
 
-The program edg-mkgridmap (found in the package `edg-mkgridmap`), used for authentication on HTCondor-CE, GridFTP, and XRootD hosts, is no longer supported by the OSG. The LCMAPS VOMS plugin (package `lcmaps-plugins-voms`) now provides the same functionality. To migrate from edg-mkgridmap to the LCMAPS VOMS plugin, perform the following procedure:
+The program edg-mkgridmap (found in the package `edg-mkgridmap`), used for authentication on HTCondor-CE, GridFTP, and
+XRootD hosts, is no longer supported by the OSG.
+The LCMAPS VOMS plugin (package `lcmaps-plugins-voms`) now provides the same functionality.
+To migrate from edg-mkgridmap to the LCMAPS VOMS plugin, perform the following procedure:
 
 1.  Configure user DN mappings:
 
@@ -133,7 +155,8 @@ The program edg-mkgridmap (found in the package `edg-mkgridmap`), used for authe
 
     1. If the above command returns a file that exists and has contents, move it to `/etc/grid-security/grid-mapfile`.
 
-1.  If you are converting an HTCondor-CE host, remove the HTCondor-CE `GRIDMAP` configuration. Otherwise, skip to the next step.
+1.  If you are converting an HTCondor-CE host, remove the HTCondor-CE `GRIDMAP` configuration. Otherwise, skip to the
+    next step.
 
     1. Find where `GRIDMAP` is set:
 
@@ -154,12 +177,14 @@ The program edg-mkgridmap (found in the package `edg-mkgridmap`), used for authe
 
     !!! warning
         In the output from this command, yum should **not** list other packages than the one.
-        If it lists other packages, cancel the erase operation, make sure the other packages are updated to their latest OSG 3.4 versions (they should have ".osg34" in their versions), and try again.
+        If it lists other packages, cancel the erase operation, make sure the other packages are updated to their latest
+        OSG 3.4 versions (they should have ".osg34" in their versions), and try again.
 
 #### Migrating from GUMS
 
 GUMS is no longer supported by the OSG and has been replaced by the LCMAPS VOMS plugin.
-Note that unlike GUMS, which runs on a central host, the LCMAPS VOMS plugin will run on your GUMS clients (e.g. HTCondor-CE, GridFTP, and XRootD).
+Note that unlike GUMS, which runs on a central host, the LCMAPS VOMS plugin will run on your GUMS clients (e.g.
+HTCondor-CE, GridFTP, and XRootD).
 To migrate any custom authentication configuration from GUMS to the LCMAPS VOMS plugin, perform the following procedure:
 
 1. On your GUMS host, retrieve the conversion helper script and run it:
@@ -168,8 +193,8 @@ To migrate any custom authentication configuration from GUMS to the LCMAPS VOMS 
         root@gums-host # wget https://raw.githubusercontent.com/opensciencegrid/osg-vo-config/mapfile-generator-0.2/bin/manual-mapfile-from-gumsdb.py
         root@gums-host # python manual-mapfile-from-gumsdb.py
 
-1. Verify that the contents of `ban-mapfile.additions`, `grid-mapfile.additions`, and `voms-mapfile.additions` include any custom
-   banned users, user mappings, and VO mappings, respectively.
+1. Verify that the contents of `ban-mapfile.additions`, `grid-mapfile.additions`, and `voms-mapfile.additions` include
+   any custom banned users, user mappings, and VO mappings, respectively.
 
     !!! note
         The above files will not include all VO mappings; the OSG provides default VO mappings in
@@ -177,8 +202,10 @@ To migrate any custom authentication configuration from GUMS to the LCMAPS VOMS 
 
 1. On each of your client hosts (e.g. HTCondor-CE, GridFTP, XRootD), perform the following:
 
-    1. If you have not done so already, [install](#installing-the-lcmaps-voms-plugin) and [configure](#configuring-the-lcmaps-voms-plugin) the LCMAPS VOMS plugin
-    1. Append each `.additions` file to its corresponding file in `/etc/grid-security/` (creating those files if they do not exist)
+    1. If you have not done so already, [install](#installing-the-lcmaps-voms-plugin) and
+       [configure](#configuring-the-lcmaps-voms-plugin) the LCMAPS VOMS plugin
+    1. Append each `.additions` file to its corresponding file in `/etc/grid-security/` (creating those files if they do
+       not exist)
 
 #### Mapping VOs
 
@@ -194,13 +221,20 @@ An example of the format of a `voms-mapfile` follows:
 "/GLOW/*" glow
 ```
 
-Each non-commented line is a shell-style pattern which is compared against the user's VOMS attributes, and a Unix account that the user will be mapped to if the pattern matches.
-The patterns are compared in the order they are listed in. Therefore, more general patterns should be placed later in the file.
+Each non-commented line is a shell-style pattern which is compared against the user's VOMS attributes, and a Unix
+account that the user will be mapped to if the pattern matches.
+The patterns are compared in the order they are listed in. Therefore, more general patterns should be placed later in
+the file.
 
 !!!note
-    The Unix account must exist for the user to be mapped. If a VO's Unix account is missing, that VO will not be able to access your resources.
+    The Unix account must exist for the user to be mapped.
+    If a VO's Unix account is missing, that VO will not be able to access your resources.
 
-    Additionally, if you map VOMS attributes to a non-existent user in `/etc/grid-security/voms-mapfile`, `/usr/share/osg/voms-mapfile-default` will be considered next to find a mapping. The best way to ban a VO is edit `/etc/grid-security/ban-voms-mapfile` as described in [Banning VOs](#banning-vos) below. Do not edit `voms-mapfile-default` as your changes will be overwritten upon updates.
+    Additionally, if you map VOMS attributes to a non-existent user in `/etc/grid-security/voms-mapfile`,
+    `/usr/share/osg/voms-mapfile-default` will be considered next to find a mapping.
+    The best way to ban a VO is edit `/etc/grid-security/ban-voms-mapfile` as described in [Banning VOs](#banning-vos)
+    below.
+    Do not edit `voms-mapfile-default` as your changes will be overwritten upon updates.
 
 
 #### Mapping users
@@ -214,22 +248,27 @@ An example of the format of a `grid-mapfile` follows:
 ```
 
 !!! note
-    The Unix account must exist for the user to be mapped. If a user's Unix account is missing, that user will not be able to access your resources.
+    The Unix account must exist for the user to be mapped. If a user's Unix account is missing, that user will not be
+    able to access your resources.
 
 
 #### Banning VOs
 
-`/etc/grid-security/ban-voms-mapfile` is used to ban an entire VO or a role withing a VO from accessing resources on your machine. An example of the format of a `ban-voms-mapfile` follows:
+`/etc/grid-security/ban-voms-mapfile` is used to ban an entire VO or a role withing a VO from accessing resources on
+your machine.
+An example of the format of a `ban-voms-mapfile` follows:
 
 ```
 # ban CMS production jobs
 "/cms/Role=production/*"
 ```
 
-Each non-commented line is a shell-style pattern which is compared against a user's VOMS attributes. If the pattern matches, that user will be unable to access your resources.
+Each non-commented line is a shell-style pattern which is compared against a user's VOMS attributes.
+If the pattern matches, that user will be unable to access your resources.
 
 !!!danger
-    When banning VOs, you must restart the services using LCMAPS VOMS authentication (e.g. `condor-ce`, `globus-gridftp-server`, etc.) to clear any authentication caches.
+    When banning VOs, you must restart the services using LCMAPS VOMS authentication (e.g. `condor-ce`,
+    `globus-gridftp-server`, etc.) to clear any authentication caches.
 
 !!!warning
     `/etc/grid-security/ban-voms-mapfile` *must* exist, even if you are not banning any VOs.
@@ -238,7 +277,8 @@ Each non-commented line is a shell-style pattern which is compared against a use
 
 #### Banning users
 
-`/etc/grid-security/ban-mapfile` is used to ban specific users from accessing your resources based on their certificates' DNs. An example of the format of a `ban-mapfile` follows:
+`/etc/grid-security/ban-mapfile` is used to ban specific users from accessing your resources based on their
+certificates' DNs. An example of the format of a `ban-mapfile` follows:
 
 ```
 # ban Matyas's FNAL DN
@@ -246,23 +286,27 @@ Each non-commented line is a shell-style pattern which is compared against a use
 ```
 
 !!!danger
-    When banning users, you must restart the services using LCMAPS VOMS authentication (e.g. `condor-ce`, `globus-gridftp-server`, etc.) to clear any authentication caches.
+    When banning users, you must restart the services using LCMAPS VOMS authentication (e.g. `condor-ce`,
+    `globus-gridftp-server`, etc.) to clear any authentication caches.
 
 !!!warning
-    `/etc/grid-security/ban-mapfile` *must* exist, even if you are not banning any users. In that case, the file should be blank. If the file does not exist, LCMAPS will ban every user.
+    `/etc/grid-security/ban-mapfile` *must* exist, even if you are not banning any users.
+    In that case, the file should be blank. If the file does not exist, LCMAPS will ban every user.
 
 
 
 ### Mapping using all FQANs
 
-By default, the LCMAPS VOMS plugin only considers the first FQAN of a VOMS proxy for mapping. If you want to consider all FQANs, you must set the appropriate option.
+By default, the LCMAPS VOMS plugin only considers the first FQAN of a VOMS proxy for mapping.
+If you want to consider all FQANs, you must set the appropriate option.
 
 -   If you are using osg-configure, set `all_fqans = True` in `10-misc.ini`, then run `osg-configure -c`
 
     !!! note
         If you are using OSG 3.4, osg-configure should be at least version 2.2.2.
 
--   If you are configuring `lcmaps.db` manually (see [manual configuration](#manual-configuration) below), add `"-all-fqans"` to the module definitions for `vomsmapfile` and `defaultmapfile`
+-   If you are configuring `lcmaps.db` manually (see [manual configuration](#manual-configuration) below),
+    add `"-all-fqans"` to the module definitions for `vomsmapfile` and `defaultmapfile`
 
 Using the LCMAPS VOMS Plugin
 ----------------------------
@@ -297,7 +341,8 @@ If you did not get correctly mapped, check your proxy's FQAN by running:
 ``` console
 user@host $ voms-proxy-info -fqan
 ```
-and make sure it matches one of the patterns in `/etc/grid-security/voms-mapfile` or `/usr/share/osg/voms-mapfile-default`, and does not match any patterns in `/etc/grid-security/ban-voms-mapfile`.
+and make sure it matches one of the patterns in `/etc/grid-security/voms-mapfile` or
+`/usr/share/osg/voms-mapfile-default`, and does not match any patterns in `/etc/grid-security/ban-voms-mapfile`.
 
 Troubleshooting the LCMAPS VOMS Plugin
 --------------------------------------
@@ -406,7 +451,7 @@ Apr 11 13:51:41 atlas-hub globus-gridftp-server: You are still root after the LC
 Getting Help
 ------------
 
-To get assistance, please use the [this page](../common/help).
+To get assistance, please use the [this page](/common/help).
 
 Reference
 ---------
@@ -429,11 +474,16 @@ The files are evaluated in the following order, with earlier files taking preced
 
 ### Manual Configuration
 
-This section is intended for use as reference if you choose to forego configuring the LCMAPS VOMS plugin via osg-configure (i.e., if you prefer a configuration management system like [Ansible](https://www.ansible.com/) or [Puppet](https://puppet.com/)). Therefore, the following instructions serve as a replacement for [this section](#applying-configuration-settings) above.
+This section is intended for use as reference if you choose to forego configuring the LCMAPS VOMS plugin via
+osg-configure (i.e., if you prefer a configuration management system like [Ansible](https://www.ansible.com/) or
+[Puppet](https://puppet.com/)).
+Therefore, the following instructions serve as a replacement for [this section](#applying-configuration-settings) above.
 
-LCMAPS is configured in `/etc/lcmaps.db`. and since the VOMS plugin is a newer component, configuration for it may not be present in your existing `/etc/lcmaps.db` file.
+LCMAPS is configured in `/etc/lcmaps.db` and since the VOMS plugin is a newer component, configuration for it may not
+be present in your existing `/etc/lcmaps.db` file.
 
-1.  Ensure the following lines are present in the "Module definitions" section (the top section, before `authorize_only`) of `/etc/lcmaps.db`:
+1.  Ensure the following lines are present in the "Module definitions" section (the top section, before
+    `authorize_only`) of `/etc/lcmaps.db`:
 
         gridmapfile = "lcmaps_localaccount.mod"
                       "-gridmap /etc/grid-security/grid-mapfile"

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -1,7 +1,7 @@
 Installing and Maintaining the LCMAPS VOMS Plugin
 =================================================
 
-LCMAPS is a software library used on [HTCondor-CE](/compute-element/install-htcondor-ce), [GridFTP](/data/gridftp), and [XRootD](/data/xrootd/install-storage-element) hosts for mapping grid certificates of incoming connections to specific Unix accounts. The LCMAPS VOMS plugin enables LCMAPS to make mapping decisions based on the VOMS attributes of grid certificates, e.g., `/cms/Role=production/Capability=NULL`. Starting in OSG 3.4, the LCMAPS VOMS plugin will replace GUMS and edg-mkgridmap as the authentication method at OSG sites.
+LCMAPS is a software library used on [HTCondor-CE](/compute-element/install-htcondor-ce), [GridFTP](/data/gridftp), and [XRootD](/data/xrootd/install-storage-element) hosts for mapping grid certificates of incoming connections to specific Unix accounts. The LCMAPS VOMS plugin enables LCMAPS to make mapping decisions based on the VOMS attributes of grid certificates, e.g., `/cms/Role=production/Capability=NULL`. In OSG 3.4, the LCMAPS VOMS plugin replaced GUMS and edg-mkgridmap as the authentication method at OSG sites.
 
 The OSG provides a default set of mappings from VOMS attributes to Unix accounts. By configuring LCMAPS, you can override these mappings, including changing the Unix account that a VO is mapped to, banning based on VOMS attributes, banning a specific user, or adding a VO, VO group, VO role, and/or user that is not in the OSG's set of mappings.
 
@@ -121,7 +121,7 @@ For a table of the configuration files and their order of evaluation, consult th
 
 #### Migrating from edg-mkgridmap
 
-The program edg-mkgridmap (found in the package `edg-mkgridmap`), used for authentication on HTCondor-CE, GridFTP, and XRootD hosts, is no longer available starting in OSG 3.4. The LCMAPS VOMS plugin (package `lcmaps-plugins-voms`) now provides the same functionality. To migrate from edg-mkgridmap to the LCMAPS VOMS plugin, perform the following procedure:
+The program edg-mkgridmap (found in the package `edg-mkgridmap`), used for authentication on HTCondor-CE, GridFTP, and XRootD hosts, is no longer supported by the OSG. The LCMAPS VOMS plugin (package `lcmaps-plugins-voms`) now provides the same functionality. To migrate from edg-mkgridmap to the LCMAPS VOMS plugin, perform the following procedure:
 
 1.  Configure user DN mappings:
 
@@ -147,13 +147,7 @@ The program edg-mkgridmap (found in the package `edg-mkgridmap`), used for authe
             :::console
             root@host # condor_ce_reconfig
 
-1. If running OSG 3.3, disable edg-mkgridmap:
-
-        :::console
-        root@host # service edg-mkgridmap stop
-        root@host # chkconfig edg-mkgridmap off
-
-1. If running OSG 3.4, remove edg-mkgridmap and related packages:
+1. Remove edg-mkgridmap and related packages:
 
         :::console
         root@host # yum erase edg-mkgridmap
@@ -164,7 +158,7 @@ The program edg-mkgridmap (found in the package `edg-mkgridmap`), used for authe
 
 #### Migrating from GUMS
 
-GUMS is no longer available starting in OSG 3.4 and is being replaced by the LCMAPS VOMS plugin.
+GUMS is no longer supported by the OSG and has been replaced by the LCMAPS VOMS plugin.
 Note that unlike GUMS, which runs on a central host, the LCMAPS VOMS plugin will run on your GUMS clients (e.g. HTCondor-CE, GridFTP, and XRootD).
 To migrate any custom authentication configuration from GUMS to the LCMAPS VOMS plugin, perform the following procedure:
 
@@ -261,12 +255,12 @@ Each non-commented line is a shell-style pattern which is compared against a use
 
 ### Mapping using all FQANs
 
-By default, the LCMAPS VOMS plugin only considers the first FQAN of a VOMS proxy for mapping. This matches the behavior of GUMS. If you want to consider all FQANs, you must set the appropriate option.
+By default, the LCMAPS VOMS plugin only considers the first FQAN of a VOMS proxy for mapping. If you want to consider all FQANs, you must set the appropriate option.
 
 -   If you are using osg-configure, set `all_fqans = True` in `10-misc.ini`, then run `osg-configure -c`
 
     !!! note
-        If you are using OSG 3.3, osg-configure should be at least version 1.10.2.  If you are using OSG 3.4, osg-configure should be at least version 2.2.2.
+        If you are using OSG 3.4, osg-configure should be at least version 2.2.2.
 
 -   If you are configuring `lcmaps.db` manually (see [manual configuration](#manual-configuration) below), add `"-all-fqans"` to the module definitions for `vomsmapfile` and `defaultmapfile`
 


### PR DESCRIPTION
There are also some references to `gums_host` in the osg-configure docs and I wasn't sure if they were still relevant so I opted to leave them alone