### PR TITLE
Updated frontend installation about port requirements for Frontend's submit hosts

### DIFF
--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -10,6 +10,9 @@ See the [HTCondor-CE Overview](htcondor-ce-overview) for a much more detailed in
 Use this page to learn how to install, configure, run, test, and troubleshoot HTCondor-CE from the OSG software
 repositories.
 
+!!! note
+    If you are installing an HTCondor-CE for use outside of the OSG, consult [this documentation](https://htcondor-wiki.cs.wisc.edu/index.cgi/wiki?p=InstallHtcondorCe)
+
 Before Starting
 ---------------
 

--- a/docs/other/install-gwms-frontend.md
+++ b/docs/other/install-gwms-frontend.md
@@ -31,7 +31,12 @@ Before Starting
 Before starting the installation process, consider the following points (consulting [the Reference section below](#reference) as needed):
 
 -   **User IDs:** If they do not exist already, the installation will create the Linux users `apache` (UID 48), `condor`, `frontend`, and `gratia`
--   **Network:** The VO frontend must have reliable network connectivity, be on the public internet (no NAT), and preferably with no firewalls. The Web server port, likely port 80, must be open. Starting from GlideinWMS 3.4.1, all the daemons on the Frontend machine have been migrated to using the shared port daemon. With this new configuration, there is no more need to open the port range 9620 to 9660 as it was, previously. But remember, if you install the user schedd on a separate host, incoming TCP port 9618 remains to be open (it was 9615 for GlideinWMS 3.4.0 and earlier). For more detailed information, see [Installing GlideinWMS Frontend on Multiple Nodes (Advanced)](#installing-glideinwms-frontend-on-multiple-nodes-advanced).
+-   **Network:** The VO frontend must have reliable network connectivity, be on the public internet (no NAT), and preferably with no firewalls. Make sure, the following ports are open:
+    -   The Web server port, likely port 80.
+    -   Port 9618, as all HTCondor daemons on the Frontend (including User Collector and Schedd) use the shared port daemon on that port.
+    -   Ports range from 9620 to 9660 if your configuration needs it(i.e. if Glideins call back on those ports) because of the secondary collectors.
+    -   For versions prior to 3.4.1, it's also required that also port 9615 and the port range 9620 to 9660 are always open.
+    Please note, if you install the user schedd on a separate host, incoming TCP port 9618 remains to be open (it was 9615 for GlideinWMS 3.4.0 and earlier). For more detailed information, see [Installing GlideinWMS Frontend on Multiple Nodes (Advanced)](#installing-glideinwms-frontend-on-multiple-nodes-advanced).
 -   **Host choice**: The GlideinWMS VO Frontend has the following hardware requirements for a production host:
     -   **CPU**: Four cores, preferably no more than 2 years old.
     -   **RAM**: 3GB plus 2MB per running job. For example, to sustain 2000 running jobs, a host with 5GB is needed.

--- a/docs/other/install-gwms-frontend.md
+++ b/docs/other/install-gwms-frontend.md
@@ -31,7 +31,7 @@ Before Starting
 Before starting the installation process, consider the following points (consulting [the Reference section below](#reference) as needed):
 
 -   **User IDs:** If they do not exist already, the installation will create the Linux users `apache` (UID 48), `condor`, `frontend`, and `gratia`
--   **Network:** The VO frontend must have reliable network connectivity, be on the public internet (no NAT), and preferably with no firewalls. Incoming TCP ports 9618 and 9620 to 9660 must be open. The Web server port, likely port 80, must be open as well.
+-   **Network:** The VO frontend must have reliable network connectivity, be on the public internet (no NAT), and preferably with no firewalls. The Web server port, likely port 80, must be open. Starting from GlideinWMS 3.4.1, all the daemons on the Frontend machine have been migrated to using the shared port daemon. With this new configuration, there is no more need to open the port range 9620 to 9660 as it was, previously. But remember, if you install the user schedd on a separate host, incoming TCP port 9618 remains to be open (it was 9615 for GlideinWMS 3.4.0 and earlier). For more detailed information, see [Installing GlideinWMS Frontend on Multiple Nodes (Advanced)](#installing-glideinwms-frontend-on-multiple-nodes-advanced).
 -   **Host choice**: The GlideinWMS VO Frontend has the following hardware requirements for a production host:
     -   **CPU**: Four cores, preferably no more than 2 years old.
     -   **RAM**: 3GB plus 2MB per running job. For example, to sustain 2000 running jobs, a host with 5GB is needed.


### PR DESCRIPTION
To preserve the port number used by the collector (contacted by the glideins) we decided to use 9618.
Hosts with the Frontend and user collector will have that port already open.
Standalone submit hosts may have only port 9615 open (it was 9615 for GlideinWMS 3.4.0 and earlier).