### PR TITLE
Revert "Add recommendation for a separate job queue location"

### DIFF
--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -27,6 +27,8 @@ Before starting the installation process, consider the following points
 -   **Network ports:** The pilot factories must be able to contact your HTCondor-CE service on port 9619 (TCP)
 -   **Submit host:** HTCondor-CE should be installed on a host that already has the ability to submit jobs into your
     local cluster
+-   **File Systems**: Non-HTCondor batch systems require a [shared file system](#batch-systems-other-than-htcondor)
+    between the HTCondor-CE host and the batch system worker nodes.
 
 As with all OSG software installations, there are some one-time (per host) steps to prepare in advance:
 

--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -27,10 +27,6 @@ Before starting the installation process, consider the following points
 -   **Network ports:** The pilot factories must be able to contact your HTCondor-CE service on port 9619 (TCP)
 -   **Submit host:** HTCondor-CE should be installed on a host that already has the ability to submit jobs into your
     local cluster
--   **File Systems:** We recommend separate partitions for the [job queue log](#configuring-the-job-queue-location) and
-    `SPOOL` directory.
-    Additionally, non-HTCondor batch systems require a [shared file system](#batch-systems-other-than-htcondor) between
-    the HTCondor-CE host and the batch system worker nodes.
 
 As with all OSG software installations, there are some one-time (per host) steps to prepare in advance:
 
@@ -137,24 +133,6 @@ SPOOL = /home/condor
 
 !!! note
     The shared spool directory must be readable and writeable by the `condor` user for HTCondor-CE to function correctly.
-
-### Configuring the job queue location
-
-The [job queue log](http://research.cs.wisc.edu/htcondor/manual/v8.6/4_5Logging_in.html#53484) is a frequently written
-to file that contains the state of the HTCondor-CE job queue.
-For performance reasons, we recommend storing this file and the `SPOOL` directory on a different file system partitions.
-To configure the location of the job queue log:
-
-1. Find which file system partition your `SPOOL` directory is located on:
-
-        :::console
-        user@htcondor-ce $ df $(condor_ce_config_val SPOOL)
-
-1. Set `JOB_QUEUE_LOG` in `/etc/condor-ce/config.d/99-local.conf` to the path of the job queue log on a separate file
-   system partition than the above.
-   For example, if you have a separate SSD that is mounted on `/ssd`, you could set the following:
-
-        JOB_QUEUE_LOG = /ssd/condor/job_queue.log
 
 ### Configuring authorization
 


### PR DESCRIPTION
This reverts commit 71910452a1b422d2b00d0a1e214e404c53e23a69.

This seems to break certain CEs; see tickets:
- https://support.opensciencegrid.org/helpdesk/tickets/6982
- https://support.opensciencegrid.org/helpdesk/tickets/8203