### PR TITLE
We only need the GitHub account name

### DIFF
--- a/docs/common/registration.md
+++ b/docs/common/registration.md
@@ -33,7 +33,7 @@ To register as an OSG contact or add your GitHub ID to your pre-existing contact
 - **If you cannot find your name**, send an email to <mailto:help@opensciencegrid.org> with the following information:
     - Full name
     - Primary email address
-    - GitHub ID
+    - GitHub account name
     - Description of your OSG affiliation, e.g. FermiGrid site administrator, senior scientist for the DUNE experiment,
       etc.
     - Contact information of site, virtual organization, or project sponsor to prove your affiliation

--- a/docs/common/registration.md
+++ b/docs/common/registration.md
@@ -33,7 +33,7 @@ To register as an OSG contact or add your GitHub ID to your pre-existing contact
 - **If you cannot find your name**, send an email to <mailto:help@opensciencegrid.org> with the following information:
     - Full name
     - Primary email address
-    - GitHub account name
+    - GitHub user name
     - Description of your OSG affiliation, e.g. FermiGrid site administrator, senior scientist for the DUNE experiment,
       etc.
     - Contact information of site, virtual organization, or project sponsor to prove your affiliation


### PR DESCRIPTION
Apparently GitHub has publicly available user IDs.

Just something I noticed from https://support.opensciencegrid.org/a/tickets/filters/5000319518