### PR TITLE
Fix backwards stratum1 squid config

### DIFF
--- a/docs/other/install-cvmfs-stratum1.md
+++ b/docs/other/install-cvmfs-stratum1.md
@@ -177,7 +177,7 @@ awk --file `dirname $0`/customhelps.awk --source '{
 
 # cache only api calls 
 insertline("^http_access deny all", "acl CVMFSAPI urlpath_regex ^/cvmfs/[^/]*/api/")
-insertline("^http_access deny all", "cache deny CVMFSAPI")
+insertline("^http_access deny all", "cache deny !CVMFSAPI")
 
 # port 80 is also supported, through an iptables redirect 
 setoption("http_port", "8000 accel defaultsite=localhost:8081 no-vhost")


### PR DESCRIPTION
This instruction has been wrong a long time, but fortunately there aren't very many cvmfs stratum 1s.  I noticed because the BNL stratum 1 had it wrong.