### PR TITLE
Remove broken formatting from install-gwms-frontend

### DIFF
--- a/docs/other/install-gwms-frontend.md
+++ b/docs/other/install-gwms-frontend.md
@@ -453,10 +453,10 @@ and renew the %GREEN%pilot proxies%ENDCOLOR% and %GREEN%VO Frontend proxy%ENDCOL
       Specify the paths to the `vo` certificate and key, and optionally, the VOMS attribute (e.g. `/osg/Role=NULL/Capability=NULL`
       for the OSG VO):
 
-            use_voms_server = %RED%false%ENDCOLOR%
-            vo_cert = %RED%<PATH TO THE PILOT CERTIFICATE>%ENDCOLOR%
-            vo_key = %RED%<PATH TO THE PILOT KEY>%ENDCOLOR%
-            fqan = %RED%<VOMS ATTRIBUTE>%ENDCOLOR%
+            use_voms_server = false
+            vo_cert = <PATH TO THE PILOT CERTIFICATE>
+            vo_key = <PATH TO THE PILOT KEY>
+            fqan = <VOMS ATTRIBUTE>
 
         !!! note
             If you do not have access to the `vo`'s `voms_cert` and `voms_key`, contact the VO manager.
@@ -464,8 +464,8 @@ and renew the %GREEN%pilot proxies%ENDCOLOR% and %GREEN%VO Frontend proxy%ENDCOL
     - To have your proxy's VOMS attributes signed by the `vo`'s VOMS server, set `use_voms_server = true`
       and the VOMS attribute (e.g. `/osg/Role=NULL/Capability=NULL` for the OSG VO):
 
-            use_voms_server = %RED%true%ENDCOLOR%
-            fqan = %RED%<VOMS ATTRIBUTE>%ENDCOLOR%
+            use_voms_server = true
+            fqan = <VOMS ATTRIBUTE>
 
         !!! warning
             Due to the [retirement of VOMS Admin server](https://opensciencegrid.org/technology/policy/voms-admin-retire/)
@@ -474,9 +474,9 @@ and renew the %GREEN%pilot proxies%ENDCOLOR% and %GREEN%VO Frontend proxy%ENDCOL
     Optionally, the proxy renewal `frequency` and `lifetime` (in hours) can be specified in each `[PILOT <NAME>]` section:
 
         # Default: 1
-        frequency = %RED%<RENEWAL FREQUENCY>%ENDCOLOR%
+        frequency = <RENEWAL FREQUENCY>
         # Default: 24
-        lifetime = %RED%<PROXY LIFETIME>%ENDCOLOR%
+        lifetime = <PROXY LIFETIME>
 
 1. Configure the location and output of the %GREEN%VO Frontend proxy%ENDCOLOR% under the `[FRONTEND]` section and set
    the `proxy_cert`, `proxy_key`, and `output` to paths corresponding to your VO Frontend:
@@ -543,8 +543,8 @@ Further, if you want to record all usage as coming from a single VO, you can con
 ``` file
 ...
     MapUnknownToGroup="1"
-    %RED%MapGroupToRole="1"%ENDCOLOR%
-    %RED%VOOverride="Engage"%ENDCOLOR%
+    MapGroupToRole="1"
+    VOOverride="Engage"
 ...
 ```
 


### PR DESCRIPTION
These color macros don't seem to work so just remove them.