### PR TITLE
Misc site install exercise fixes

### DIFF
--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -393,7 +393,7 @@ Registering the CE
 ------------------
 
 To be part of the OSG Production Grid, your CE must be
-[registered with the OSG](https://github.com/opensciencegrid/topology#topology)
+[registered with the OSG](https://github.com/opensciencegrid/topology#topology).
 To register your resource:
 
 1.  Identify the facility, site, and resource group where your HTCondor-CE is hosted.

--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -371,7 +371,8 @@ Validating HTCondor-CE
 To validate an HTCondor-CE, perform the following verification steps:
 
 1. Verify that local job submissions complete successfully from the CE host.
-   For example, run `sbatch` from the CE and verify that it runs and completes in your Slurm cluster.
+   For example, if you have a Slurm cluster, run `sbatch` from the CE and verify that it runs and completes with
+   `scontrol` and `sacct`.
 
 1. Verify that all the necessary daemons are running with
    [condor\_ce\_status -any](/compute-element/troubleshoot-htcondor-ce#condor_ce_status).

--- a/docs/compute-element/install-htcondor-ce.md
+++ b/docs/compute-element/install-htcondor-ce.md
@@ -374,7 +374,7 @@ To validate an HTCondor-CE, perform the following verification steps:
    For example, run `sbatch` from the CE and verify that it runs and completes in your Slurm cluster.
 
 1. Verify that all the necessary daemons are running with
-   [condor\_ce\_status](/compute-element/troubleshoot-htcondor-ce#condor_ce_status).
+   [condor\_ce\_status -any](/compute-element/troubleshoot-htcondor-ce#condor_ce_status).
 
 1. Verify the CE's network configuration using
    [condor\_ce\_host\_network\_check](/compute-element/troubleshoot-htcondor-ce#condor_ce_host_network_check).

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -46,20 +46,6 @@ The following section describes the steps required to configure the LCMAPS VOMS 
 Additionally, there are [optional configuration](#optional-configuration) instructions if you need to make changes to
 the default mappings, or migrate from edg-mkgridmap or GUMS.
 
-
-### Enabling the LCMAPS VOMS plugin
-
-To configure your host to use LCMAPS VOMS plugin authentication, edit `/etc/osg/config.d/10-misc.ini` and set the
-following options:
-
-``` ini
-edit_lcmaps_db = True
-authorization_method = vomsmap
-```
-
-If the `glexec_location` option is present, you must comment it out or set it to `UNAVAILABLE`.
-The LCMAPS VOMS plugin does not work with gLExec.
-
 ### Supporting mapped VOs and users
 
  Ensure Unix accounts exist for each VO, VO role, VO group, or user you choose to support in the [mapfiles](#configuration-files):

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -71,9 +71,6 @@ the default mappings, or migrate from edg-mkgridmap or GUMS.
     | [HCC](https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/HCC.yaml)           | `hcc`               |
     | [Gluex](https://github.com/opensciencegrid/topology/blob/master/virtual-organizations/Gluex.yaml)       | `gluex`             |
 
-    Additionally, it is also recommended to create the `mis` Unix account,
-    which is used by OSG staff to assist with troubleshooting.
-
 1.  Edit `/etc/osg/config.d/30-gip.ini` and specify the supported VOs per [Subcluster or ResourceEntry section](/other/configuration-with-osg-configure#subcluster-resource-entry):
 
         :::ini

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -284,9 +284,6 @@ If you want to consider all FQANs, you must set the appropriate option.
 
 -   If you are using osg-configure, set `all_fqans = True` in `10-misc.ini`, then run `osg-configure -c`
 
-    !!! note
-        If you are using OSG 3.4, osg-configure should be at least version 2.2.2.
-
 -   If you are configuring `lcmaps.db` manually (see [manual configuration](#manual-configuration) below),
     add `"-all-fqans"` to the module definitions for `vomsmapfile` and `defaultmapfile`
 


### PR DESCRIPTION
I thought about modifying the `allowed_vos` instructions to just tell users to use `*` but saw that the instructions mention it's per subcluster. If we change this, we should probably just have the default to `*` in osg-configure and tell people that they should only change it if they need to restrict access