### PR TITLE
Generalize the network namespace warning in install-singularity

### DIFF
--- a/docs/worker-node/install-singularity.md
+++ b/docs/worker-node/install-singularity.md
@@ -139,9 +139,9 @@ steps:
     disabling them reduces the risk profile of enabling user
     namespaces.
 
-    Network namespaces are, however, utilized by other container
-    systems, such as Docker.  Disabling network namespaces may break
-    other container solutions, or limit their capabilities (such as
+    Network namespaces are, however, utilized by other software,
+    such as Docker.  Disabling network namespaces may break
+    other software, or limit its capabilities (such as
     requiring the `--net=host` option in Docker).
 
 1. If you haven't yet installed [CVMFS](install-cvmfs), do so.


### PR DESCRIPTION
I heard that somebody had a non-container system (a remote desktop application) that also used network namespaces.