### PR TITLE
Replace broken TWiki highlight macros with a line highlight

### DIFF
--- a/docs/common/registration.md
+++ b/docs/common/registration.md
@@ -152,12 +152,12 @@ To modify an existing resource, follow these instructions:
 
 To retire an already registered resource, set `Active: false`. For example:
 
-```
+``` hl_lines="5"
 ...
 Production: true
 Resources:
   GLOW:
-    Active: %RED%false%ENDCOLOR%
+    Active: false
     ...
     Services:
       CE:


### PR DESCRIPTION
![highlight_lines](https://user-images.githubusercontent.com/390105/58965810-cefba600-8776-11e9-9515-718a5877aa3e.png)
