### PR TITLE
Add warning about exporting top directory level

### DIFF
--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -101,6 +101,9 @@ With this configuration, the data under `/mnt/stash/hcc/bio/datasets` would be a
     Directories you export **must not** collide with directories provided by other origin servers; this is
     why the explicit registration is required.
 
+!!! warning
+    The origin can only export one directory level below the `rootdir`,
+    so exporting `/hcc` would work, but exporting `/hcc/data1` would not work.
 
 Managing the Origin Service
 ---------------------------


### PR DESCRIPTION
Found this out while trying to set up the icecube export: `all.export /icecube/PUBLIC` didn't work so I had to do `all.export /icecube`.