### PR TITLE
Address some more XRootD standalone issues

### DIFF
--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -295,8 +295,6 @@ fermicloud054.fnal.gov complete inventory as of Tue Apr 12 07:38:29 2011 /data/x
 XRootD can be accessed using the HTTP protocol. To do that:
 
 1.  Modify `/etc/xrootd/xrootd-clustered.cfg` and add the following lines.
-    You will also need to add the configuration regarding
-    [LCMAPS authorization](/data/xrootd/xrootd-authorization).
 
         :::file
            if exec xrootd
@@ -309,7 +307,9 @@ XRootD can be accessed using the HTTP protocol. To do that:
             http.staticpreload http://static/robots.txt /etc/xrootd/robots.txt
             http.desthttps yes
            fi
-  
+
+1. Add [LCMAPS authorization](/data/xrootd/xrootd-authorization) configuration to `/etc/xrootd/xrootd-clustered.cfg`.
+
 1.   Create robots.txt. Add file `/etc/xrootd/robots.txt` with these contents:
 
         :::file

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -40,31 +40,6 @@ root@host # yum install xrootd
 Configuring an XRootD Server
 ----------------------------
 
-### Minimal configuration
-
-A new installation of XRootD is already configured to run a standalone server that serves files from `/tmp` on the local
-file system. 
-This configuration is useful to verify basic connectivity between your clients and your server. 
-To do this, start the `xrootd` service with standalone config as described in the [managing services
-section](#managing-xrootd-services).
-
-You should be able now to copy a file such as `/bin/sh` using `xrdcp` command into `/tmp`. 
-To test, do:
-
-``` console
-root@host # yum install xrootd-client
-root@host # xrdcp /bin/sh root://localhost:1094//tmp/first_test
-[xrootd] Total 0.76 MB  [====================] 100.00 % [inf MB/s]
-root@host # ls -l /tmp/first_test
--rw-r--r-- 1 xrootd xrootd 801512 Apr 11 10:48 /tmp/first_test
-```
-
-Other than for testing, a standalone server is useful when you want to serve files off of a single host with lots of
-large disks. 
-If your storage capacity is spread out over multiple hosts, you will need to set up an XRootD cluster.
-
-### Advanced configuration
-
 An advanced XRootD setup has multiple components; it is important to validate that each additional component that you
 set up is working before moving on to the next component. 
 We have included validation instructions after each component below.

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -294,7 +294,9 @@ fermicloud054.fnal.gov complete inventory as of Tue Apr 12 07:38:29 2011 /data/x
 
 XRootD can be accessed using the HTTP protocol. To do that:
 
-1.   Modify `/etc/xrootd/xrootd-clustered.cfg` and add the following lines. You will also need to add the configuration regarding [lcmaps authorization](#security-option-3-xrootd-lcmaps-authorization).
+1.  Modify `/etc/xrootd/xrootd-clustered.cfg` and add the following lines.
+    You will also need to add the configuration regarding
+    [LCMAPS authorization](/data/xrootd/xrootd-authorization).
 
         :::file
            if exec xrootd

--- a/docs/data/xrootd/overview.md
+++ b/docs/data/xrootd/overview.md
@@ -19,7 +19,7 @@ help reduce incoming WAN usage.
 In the OSG, there are three data federations based on XCache: ATLAS XCache, CMS XCache, and
 [StashCache](/data/stashcache/overview).
 
-If you are affiliated with a site or VO interested in contributing to or starting a data federation, contact us at
+If you are affiliated with a site or VO interested in contributing to a data federation, contact us at
 <mailto:help@opensciencegrid.org>.
 
 XRootD Standalone

--- a/docs/data/xrootd/overview.md
+++ b/docs/data/xrootd/overview.md
@@ -17,7 +17,7 @@ more VOs.
 If your site contributes large amounts of computing resources to the OSG, a site XCache could be part of a solution to
 help reduce incoming WAN usage.
 In the OSG, there are three data federations based on XCache: ATLAS XCache, CMS XCache, and
-[StashCache](/data/stashcache/overview).
+[StashCache](/data/stashcache/overview) for all other VOs.
 
 If you are affiliated with a site or VO interested in contributing to a data federation, contact us at
 <mailto:help@opensciencegrid.org>.

--- a/docs/data/xrootd/overview.md
+++ b/docs/data/xrootd/overview.md
@@ -23,8 +23,8 @@ If you are affiliated with a site or VO interested in contributing to or startin
 XRootD Standalone
 -----------------
 
-An [XRootD standalone server](/data/xrootd/install-standalone) exports an existing filesystem, such as HDFS or Lustre, 
-using both the XRootD and WebDAV protocols.
+An [XRootD standalone server](/data/xrootd/install-standalone) exports an existing network storage solution, such as
+HDFS or Lustre, using both the XRootD and WebDAV protocols.
 Generally, only sites affiliated with large VOs would need to install an XRootD standalone server so consult your VO if
 you are interested in contributing storage.
 

--- a/docs/data/xrootd/overview.md
+++ b/docs/data/xrootd/overview.md
@@ -14,6 +14,8 @@ XCache
 
 Previously known as the "XRootD proxy cache", XCache provides a caching service for data federations that serve one or
 more VOs.
+If your site contributes large amounts of computing resources to the OSG, a site XCache could be part of a solution to
+help reduce incoming WAN usage.
 In the OSG, there are three data federations based on XCache: ATLAS XCache, CMS XCache, and
 [StashCache](/data/stashcache/overview).
 

--- a/docs/data/xrootd/overview.md
+++ b/docs/data/xrootd/overview.md
@@ -7,7 +7,7 @@ The software can be used to create a export an existing file system through mult
 federation, or act as a caching service.
 XRootD data servers can stream data directly to client applications or support experiment-wide data management by
 performing bulk data transfer via "third-party-copy" between distinct sites.
-The OSG currently supports two different configurations of XRootD:
+The OSG currently supports three different configurations of XRootD:
 
 XCache
 ------
@@ -27,3 +27,11 @@ An [XRootD standalone server](/data/xrootd/install-standalone) exports an existi
 using both the XRootD and WebDAV protocols.
 Generally, only sites affiliated with large VOs would need to install an XRootD standalone server so consult your VO if
 you are interested in contributing storage.
+
+XRootD Storage Element
+----------------------
+
+An [XRootD storage element (SE)](/data/xrootd/install-storage-element) is a network storage solution that enables
+external VO access using both the XRootD and WebDAV protocols.
+Generally, only sites affiliated with large VOs would need to install an XRootD SE so consult your VO if you are
+interested in contributing storage.

--- a/docs/data/xrootd/overview.md
+++ b/docs/data/xrootd/overview.md
@@ -7,7 +7,7 @@ The software can be used to create a export an existing file system through mult
 federation, or act as a caching service.
 XRootD data servers can stream data directly to client applications or support experiment-wide data management by
 performing bulk data transfer via "third-party-copy" between distinct sites.
-The OSG currently supports three different configurations of XRootD:
+The OSG supports multiple different configurations of XRootD:
 
 XCache
 ------

--- a/docs/data/xrootd/overview.md
+++ b/docs/data/xrootd/overview.md
@@ -25,15 +25,15 @@ If you are affiliated with a site or VO interested in contributing to a data fed
 XRootD Standalone
 -----------------
 
-An [XRootD standalone server](/data/xrootd/install-standalone) exports an existing network storage solution, such as
-HDFS or Lustre, using both the XRootD and WebDAV protocols.
+An [XRootD standalone server](/data/xrootd/install-standalone) exports data from an existing network storage solution,
+such as HDFS or Lustre, using both the XRootD and WebDAV protocols.
 Generally, only sites affiliated with large VOs would need to install an XRootD standalone server so consult your VO if
 you are interested in contributing storage.
 
 XRootD Storage Element
 ----------------------
 
-An [XRootD storage element (SE)](/data/xrootd/install-storage-element) is a network storage solution that enables
-external VO access using both the XRootD and WebDAV protocols.
+For an [XRootD storage element (SE)](/data/xrootd/install-storage-element), the XRootD software acts as the network
+storage technology, exporting data from multiple, distributed hosts using both the XRootD and WebDAV protocols.
 Generally, only sites affiliated with large VOs would need to install an XRootD SE so consult your VO if you are
 interested in contributing storage.

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -120,6 +120,9 @@ on all data nodes:
 
 1. Restart the [relevant services](/data/xrootd/install-standalone/#using-xrootd)
 
+Verifying XRootD Authorization
+------------------------------
+
 To verify the LCMAPS security, run the following commands from a machine with your user certificate/key pair,
 `xrootd-client`, and `voms-clients-cpp` installed:
 

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -113,7 +113,7 @@ on all data nodes:
                                 -key:/etc/grid-security/xrd/xrdkey.pem \
                                 -crl:1 \
                                 -authzfun:libXrdLcmaps.so \
-                                -authzfunparms:--loglevel=0,--policy=authorize_only \
+                                -authzfunparms:--lcmapscfg=/etc/xrootd/lcmaps.cfg,--loglevel=0,--policy=authorize_only \
                                 -gmapopt:10 -gmapto:0
             acc.authdb /etc/xrootd/auth_file
             ofs.authorize

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -110,8 +110,10 @@ on all data nodes:
             xrootd.seclib /usr/lib64/libXrdSec-4.so
             sec.protocol /usr/lib64 gsi -certdir:/etc/grid-security/certificates \
                                 -cert:/etc/grid-security/xrd/xrdcert.pem \
-                                -key:/etc/grid-security/xrd/xrdkey.pem -crl:1 \
-                                -authzfun:libXrdLcmaps.so -authzfunparms:--loglevel,0,--policy,authorize_only \
+                                -key:/etc/grid-security/xrd/xrdkey.pem \
+                                -crl:1 \
+                                -authzfun:libXrdLcmaps.so \
+                                -authzfunparms:--loglevel=0,--policy=authorize_only \
                                 -gmapopt:10 -gmapto:0
             acc.authdb /etc/xrootd/auth_file
             ofs.authorize

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -1,7 +1,7 @@
 Configuring XRootD Authorization
 ================================
 
-There are several authorization options in XRootD available through the security plugins. 
+There are several authorization options in XRootD available through its security plugins.
 In this document, we will cover the [`xrootd-lcmaps`](#enabling-xrootd-lcmaps-authorization) security option supported
 in the OSG.
 

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -371,7 +371,7 @@ If you are troubleshooting an XRootD host, follow these instructions to raise th
                     -key:/etc/grid-security/xrootd/xrootdkey.pem \
                     -crl:1 \
                     -authzfun:libXrdLcmaps.so \
-                    -authzfunparms:--loglevel=5 \
+                    -authzfunparms:--lcmapscfg=/etc/xrootd/lcmaps.cfg,--loglevel=5,--policy=authorize_only \
                     -gmapopt:10 -gmapto:0
 
 1. Restart the [xrootd](/data/xrootd/install-storage-element#managing-xrootd-services) service

--- a/docs/security/lcmaps-voms-authentication.md
+++ b/docs/security/lcmaps-voms-authentication.md
@@ -363,12 +363,15 @@ If you are troubleshooting an XRootD host, follow these instructions to raise th
     | Standalone mode                 | `/etc/xrootd/xrootd-standalone.cfg` |
     | Clustered mode                  | `/etc/xrootd/xrootd-clustered.cfg`  |
 
-1. Set `--loglevel,5` under the `-authzfunparms` of the `sec.protocol /usr/lib64 gsi` line. For example:
+1. Set `--loglevel=5` under the `-authzfunparms` of the `sec.protocol /usr/lib64 gsi` line. For example:
 
+        :::file hl_lines="6"
         sec.protocol /usr/lib64 gsi -certdir:/etc/grid-security/certificates \
                     -cert:/etc/grid-security/xrootd/xrootdcert.pem \
-                    -key:/etc/grid-security/xrootd/xrootdkey.pem -crl:1 \
-                    -authzfun:libXrdLcmaps.so -authzfunparms:%RED%--loglevel,5%ENDCOLOR% \
+                    -key:/etc/grid-security/xrootd/xrootdkey.pem \
+                    -crl:1 \
+                    -authzfun:libXrdLcmaps.so \
+                    -authzfunparms:--loglevel=5 \
                     -gmapopt:10 -gmapto:0
 
 1. Restart the [xrootd](/data/xrootd/install-storage-element#managing-xrootd-services) service


### PR DESCRIPTION
This addresses a few more [XRootD standalone doc issues](https://docs.google.com/document/d/1aXAaGpeKL45AcuYarKOzvHNzMopOEUmd2T08b2bWBYo/edit?usp=sharing) apart from:

- Stuff that should go into `osg-xrootd`
- The XRootD configuration that we tell them to edit in the XRootD AuthZ doc (this seems right to me)
- Host cert vs service cert location
