### PR TITLE
Update XRootD standalone doc to use osg-xrootd (SOFTWARE-3557)

### DIFF
--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -73,10 +73,6 @@ under `/etc/xrootd/config.d/` as follows:
     !!! note
         CMS sites should follow CMS policy for `resourcename`
 
-1.  Append the following configuration to the end of `/etc/xrootd/xrootd-standalone.cfg`
-
-        all.role server
-
 1.  On EL 6, set the default options to use the standalone configuration in the `/etc/sysconfig/xrootd` file.
 
         XROOTD_DEFAULT_OPTIONS="-l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-standalone.cfg -k fifo"

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -198,6 +198,7 @@ root@host # systemctl start xrootd@standalone
 | Service/Process | Configuration File                  | Description               |
 |:----------------|:------------------------------------|:--------------------------|
 | `xrootd`        | `/etc/xrootd/xrootd-standalone.cfg` | Main XRootD configuration |
+|                 | `/etc/xrootd/config.d/`             | Drop-in configuration dir |
 |                 | `/etc/xrootd/auth_file`             | Authorized users file     |
 
 | Service/Process          | Log File                                | Description                                 |

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -30,10 +30,10 @@ As with all OSG software installations, there are some one-time (per host) steps
 Installing XRootD
 -----------------
 
-To install XRootD, run the following Yum command:
+To install the XRootD Standalone server, run the following Yum command:
 
 ``` console
-root@xrootd-standalone # yum install xrootd
+root@xrootd-standalone # yum install osg-xrootd-standalone
 ```
 
 Configuring XRootD

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -44,9 +44,16 @@ under `/etc/xrootd/config.d/` as follows:
 
 1.  Comment out the `all.export /tmp` directive in `/etc/xrootd/xrootd-standalone.cfg`.
 
-1.  Comment out the `all.export /` directive in `/etc/xrootd/config.d/90-osg-standalone-paths.cfg`,
-    and add an `all.export` directive for each directory that you wish to serve via XRootD.
-    For example, to serve the contents of `/store` and `/public`:
+1.  Configure a `rootdir` in `/etc/xrootd/config.d/10-common-site-local.cfg`, to point to the top of the directory
+    hierarchy which you wish to serve via XRootD.
+    For example, to serve `/data`:
+
+        set rootdir = /data
+
+1.  To limit the sub-directories to serve under your configured `rootdir`, comment out the `all.export /` directive in
+    `/etc/xrootd/config.d/90-osg-standalone-paths.cfg`, and add an `all.export` directive for each directory under
+    `rootdir` that you wish to serve via XRootD.
+    For example, to serve the contents of `/data/store` and `/data/public` (with `rootdir` configured to `/data`):
 
         all.export /store/
         all.export /public/

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -87,11 +87,6 @@ The following configuration steps are optional and will likely not be required f
 If you do not need any of the following special configurations, skip to
 [the section on using XRootD](#using-xrootd).
 
-#### Enabling HTTP support
-
-In order to enable XRootD HTTP support please follow the instructions
-[here](/data/xrootd/install-storage-element#optional-enabling-xrootd-over-http)
-
 #### Enabling Hadoop support (EL 7 Only)
 
 For documentation on how to export your Hadoop storage using XRootD please see

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -39,9 +39,13 @@ root@xrootd-standalone # yum install osg-xrootd-standalone
 Configuring XRootD
 ------------------
 
-To configure XRootD as a standalone server, replace the contents of `/etc/xrootd/xrootd-standalone.cfg` as follows:
+To configure XRootD as a standalone server, you will modify `/etc/xrootd/xrootd-standalone.cfg` and the config files
+under `/etc/xrootd/config.d/` as follows:
 
-1.  Add an `all.export` directive for each directory that you wish to serve via XRootD.
+1.  Comment out the `all.export /tmp` directive in `/etc/xrootd/xrootd-standalone.cfg`.
+
+1.  Comment out the `all.export /` directive in `/etc/xrootd/config.d/90-osg-standalone-paths.cfg`,
+    and add an `all.export` directive for each directory that you wish to serve via XRootD.
     For example, to serve the contents of `/store` and `/public`:
 
         all.export /store/

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -42,8 +42,6 @@ Configuring XRootD
 To configure XRootD as a standalone server, you will modify `/etc/xrootd/xrootd-standalone.cfg` and the config files
 under `/etc/xrootd/config.d/` as follows:
 
-1.  Comment out the `all.export /tmp` directive in `/etc/xrootd/xrootd-standalone.cfg`.
-
 1.  Configure a `rootdir` in `/etc/xrootd/config.d/10-common-site-local.cfg`, to point to the top of the directory
     hierarchy which you wish to serve via XRootD.
     For example, to serve `/data`:

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -55,16 +55,16 @@ under `/etc/xrootd/config.d/` as follows:
         The directories specified this way are writable by default.
         Access controls should be managed via [authorization configuration](#configuring-authorization).
 
-1. Add an `all.sitename` directive set to the [resource name](/common/registration/#registering-resources) of your
-   XRootD service.
+1. In `/etc/xrootd/config.d/10-common-site-local.cfg`, add a line to set the `resourcename` variable to the
+   [resource name](/common/registration/#registering-resources) of your XRootD service.
    For example, the XRootD service registered at the
    [FermiGrid site](https://github.com/opensciencegrid/topology/blob/master/topology/Fermi%20National%20Accelerator%20Laboratory/FermiGrid/FNAL_PUBLIC_DCACHE.yaml#L6)
    should set the following configuration:
 
-        all.sitename   Fermilab Public DCache
+        set resourcename = Fermilab Public DCache
 
     !!! note
-        CMS sites should follow CMS policy for `all.sitename`
+        CMS sites should follow CMS policy for `resourcename`
 
 1.  Append the following configuration to the end of `/etc/xrootd/xrootd-standalone.cfg`
 

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -68,26 +68,7 @@ under `/etc/xrootd/config.d/` as follows:
 
 1.  Append the following configuration to the end of `/etc/xrootd/xrootd-standalone.cfg`
 
-        xrd.port 1094
         all.role server
-
-        cms.allow host *
-        # Logging verbosity
-        xrootd.trace emsg login stall redirect
-        ofs.trace -all
-        xrd.trace conn
-        cms.trace all
-
-        xrd.report xrd-report.osgstorage.org:9931
-        xrootd.monitor all \
-                       auth \
-                       flush 30s \
-                       window 5s fstat 60 lfn ops xfr 5 \
-                       dest redir fstat info user xrd-report.osgstorage.org:9930 \
-                       dest fstat info user xrd-mon.osgstorage.org:9930
-
-        xrd.network keepalive kaparms 10m,1m,5
-        xrd.timeout idle 60m
 
 1.  On EL 6, set the default options to use the standalone configuration in the `/etc/sysconfig/xrootd` file.
 

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -273,7 +273,7 @@ fermicloud054.fnal.gov complete inventory as of Tue Apr 12 07:38:29 2011 /data/x
 
 XRootD can be accessed using the HTTP protocol. To do that:
 
-1. Add [LCMAPS authorization](/data/xrootd/xrootd-authorization) configuration to `/etc/xrootd/xrootd-clustered.cfg`.
+1. Configure [LCMAPS authorization](/data/xrootd/xrootd-authorization).
 
 1.   Create robots.txt. Add file `/etc/xrootd/robots.txt` with these contents:
 

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -275,6 +275,11 @@ XRootD can be accessed using the HTTP protocol. To do that:
 
 1. Configure [LCMAPS authorization](/data/xrootd/xrootd-authorization).
 
+1. Uncomment the following line in `/etc/xrootd/config.d/10-xrootd-lcmaps.cfg`:
+
+        :::file
+        set EnableLcmaps = 1
+
 1.   Testing the configuration
     
      From the terminal, generate a proxy and attempt to use davix-get to copy from your XRootD host (the XRootD service needs running; see the [services section](#managing-xrootd-services)).  For example, if your server has a file named `/store/user/test.root`:

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -275,12 +275,6 @@ XRootD can be accessed using the HTTP protocol. To do that:
 
 1. Configure [LCMAPS authorization](/data/xrootd/xrootd-authorization).
 
-1.   Create robots.txt. Add file `/etc/xrootd/robots.txt` with these contents:
-
-        :::file
-           User-agent: *
-           Disallow: / 
-
 1.   Testing the configuration
     
      From the terminal, generate a proxy and attempt to use davix-get to copy from your XRootD host (the XRootD service needs running; see the [services section](#managing-xrootd-services)).  For example, if your server has a file named `/store/user/test.root`:

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -280,6 +280,11 @@ XRootD can be accessed using the HTTP protocol. To do that:
         :::file
         set EnableLcmaps = 1
 
+1. Add the following line to `/etc/xrootd/config.d/10-common-site-local.cfg`:
+
+        :::file
+        set EnableHttp = 1
+
 1.   Testing the configuration
     
      From the terminal, generate a proxy and attempt to use davix-get to copy from your XRootD host (the XRootD service needs running; see the [services section](#managing-xrootd-services)).  For example, if your server has a file named `/store/user/test.root`:

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -273,20 +273,6 @@ fermicloud054.fnal.gov complete inventory as of Tue Apr 12 07:38:29 2011 /data/x
 
 XRootD can be accessed using the HTTP protocol. To do that:
 
-1.  Modify `/etc/xrootd/xrootd-clustered.cfg` and add the following lines.
-
-        :::file
-           if exec xrootd
-            xrd.protocol http:1094 libXrdHttp.so
-            http.cadir /etc/grid-security/certificates
-            http.cert /etc/grid-security/xrd/xrdcert.pem
-            http.key /etc/grid-security/xrd/xrdkey.pem
-            http.secxtractor /usr/lib64/libXrdLcmaps.so
-            http.listingdeny yes
-            http.staticpreload http://static/robots.txt /etc/xrootd/robots.txt
-            http.desthttps yes
-           fi
-
 1. Add [LCMAPS authorization](/data/xrootd/xrootd-authorization) configuration to `/etc/xrootd/xrootd-clustered.cfg`.
 
 1.   Create robots.txt. Add file `/etc/xrootd/robots.txt` with these contents:

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -38,7 +38,7 @@ An installation of the XRootD server consists of the server itself and its depen
 Install these with Yum:
 
 ``` console
-root@host # yum install xrootd
+root@host # yum install osg-xrootd
 ```
 
 Configuring an XRootD Server

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -280,7 +280,7 @@ XRootD can be accessed using the HTTP protocol. To do that:
         :::file
         set EnableLcmaps = 1
 
-1. Add the following line to `/etc/xrootd/config.d/10-common-site-local.cfg`:
+1. Additionally, add the following line to the same file:
 
         :::file
         set EnableHttp = 1

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -100,28 +100,6 @@ on all data nodes:
 
 1. Configure access rights for mapped users by creating and modifying the XRootD [authorization file](#authorization-file)
 
-1. Modify your XRootD configuration:
-
-    1. Choose the configuration file to edit based on the following table:
-
-        | If you are running XRootD in... | Then modify the following file...   |
-        |:--------------------------------|:------------------------------------|
-        | Standalone mode                 | `/etc/xrootd/xrootd-standalone.cfg` |
-        | Clustered mode                  | `/etc/xrootd/xrootd-clustered.cfg`  |
-
-    1. Add the following lines to the configuration that you chose above:
-
-            xrootd.seclib /usr/lib64/libXrdSec-4.so
-            sec.protocol /usr/lib64 gsi -certdir:/etc/grid-security/certificates \
-                                -cert:/etc/grid-security/xrd/xrdcert.pem \
-                                -key:/etc/grid-security/xrd/xrdkey.pem \
-                                -crl:1 \
-                                -authzfun:libXrdLcmaps.so \
-                                -authzfunparms:lcmapscfg=/etc/lcmaps.db,loglevel=0,policy=authorize_only \
-                                -gmapopt:10 -gmapto:0
-            acc.authdb /etc/xrootd/auth_file
-            ofs.authorize
-
 1. Restart the [relevant services](/data/xrootd/install-standalone/#using-xrootd)
 
 Verifying XRootD Authorization


### PR DESCRIPTION
Clean up old manual config steps now done by drop-in config.d files brought in by the osg-xrootd-standalone package

Closes: #509 