### PR TITLE
Add rolling release tip to the release note overview

### DIFF
--- a/docs/release/notes.md
+++ b/docs/release/notes.md
@@ -6,6 +6,18 @@ This page contains links to detailed notes for release in the currently supporte
 For our policy on release series support, please consult
 [this page](https://opensciencegrid.org/technology/policy/release-series/).
 
+!!!tip "Want faster access to production-ready software?"
+    OSG 3.5 and 3.4 offer a rolling release repository where packages are added as soon as they pass acceptance testing.
+    To install packages from this repository, enable `[osg-rolling]` in `/etc/yum.repos.d/osg-rolling.repo`:
+
+        [osg-rolling]
+        ...
+        enabled=1
+
+    Or for one-time installations, append the following to your `yum` command:
+
+        --enablerepo=osg-rolling
+
 OSG 3.5
 -------
 


### PR DESCRIPTION
Since we eventually want to move toward rolling releases within a release series, let's ramp up our advertisement of the rolling release repo. We should probably add this same note prominently to each point release page