### PR TITLE
Update HTCondor manual links

### DIFF
--- a/docs/release/3.5/release-3-5-0.md
+++ b/docs/release/3.5/release-3-5-0.md
@@ -32,7 +32,7 @@ To update to the OSG 3.5 release series, please consult the page on
 In addition to the packages that were carried over from [OSG 3.4.33](/release/3.4/release-3-4-33#),
 this release contains the following package updates:
 
--   HTCondor 8.8.4: The current HTCondor [stable release](https://htcondor.readthedocs.io/en/v8_8_4/version-history/stable-release-series-88.html).
+-   HTCondor 8.8.4: The current HTCondor [stable release](https://htcondor.readthedocs.io/en/stable/version-history/stable-release-series-88.html#version-8-8-4).
     See the [manual update instructions](/release/release_series#updating-to-htcondor-88x_1) before
     updating to this version.
     Some highlights from the 8.8 release series include:
@@ -74,7 +74,7 @@ this release contains the following package updates:
 -   OSG System Profiler 1.4.3: Remove collection of obsolete information
     See the known issue with this version [below](#known-issues).
 -   HTCondor 8.9.2 (upcoming): The current HTCondor
-    [development release](https://htcondor.readthedocs.io/en/v8_9_2/version-history/development-release-series-89.html).
+    [development release](https://htcondor.readthedocs.io/en/latest/version-history/development-release-series-89.html#version-8-9-2).
     Some highlights from the 8.9 release series include:
     -   New TOKEN authentication method enables fine-grained authorization control
     -   All HTCondor daemons run under a condor\_master share a security session

--- a/docs/release/release_series.md
+++ b/docs/release/release_series.md
@@ -216,7 +216,7 @@ Updating to HTCondor 8.8.x
 The OSG 3.5 and 3.4 release series contain HTCondor 8.8, a major version upgrade from the previously released versions
 in the OSG.
 See the HTCondor 8.8 manual for an overview of the
-[changes](https://htcondor.readthedocs.io/en/v8_8_4/version-history/upgrading-from-86-to-88-series.html).
+[changes](https://htcondor.readthedocs.io/en/stable/version-history/upgrading-from-86-to-88-series.html).
 To update HTCondor on your HTCondor-CE and/or HTCondor pool hosts, perform the following steps:
 
 1. Update all HTCondor packages:
@@ -231,7 +231,7 @@ To update HTCondor on your HTCondor-CE and/or HTCondor pool hosts, perform the f
       If you are experiencing issues with communication between hosts in your pool after the upgrade,
       the default OSG configuration is listed in `/etc/condor/config.d/00-osg_default_*.config`:
       ensure that any default configuration is overriden with your own `DAEMON_LIST`, `CONDOR_HOST`, and/or
-      [security](https://htcondor.readthedocs.io/en/v8_8_4/admin-manual/security.html) configuration in subsequent files.
+      [security](https://htcondor.readthedocs.io/en/stable/admin-manual/security.html) configuration in subsequent files.
 
     - As of HTCondor 8.8, [MOUNT_UNDER_SCRATCH](https://htcondor.readthedocs.io/en/stable/admin-manual/configuration-macros.html#condor-startd-configuration-file-macros)
       has default values of `/tmp` and `/var/tmp`, which may cause issues if your


### PR DESCRIPTION
The HTCondor team dropped 8.8.x tags for their documentation. Use
stable instead.