### PR TITLE
Add initial documentation for accepting COVID-19 pilots.

### DIFF
--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -1,0 +1,104 @@
+
+Supporting COVID-19 Research on the OSG
+=======================================
+
+There are a number of options available for sites wanting to support the
+important and urgent work of COVID-19 researchers using the OSG.  The OSG VO
+provides sites with the opportunity to accept pilots that _exclusively_ run
+jobs relating to COVID-19 research and account for this usage separately
+from other OSG activity.
+
+To support this work, one must:
+
+1. Make the site computing resources available through a HTCondor-CE.  This
+can be done through an [on-premise](/compute-element/install-htcondor-ce/)
+instance or asking OSG to [host the CE](/compute-element/hosted-ce/) on your
+behalf.  If neither solution is viable, please send email to
+<help@opensciencegrid.org> and we can provide consulting services to determine
+a better approach.
+2. Enable the OSG VO and setup a job route specific to COVID-19 pilot jobs.
+This process is documented below.  This enables you to prioritize these jobs
+according to your local policy.
+3. Send email to <help@opensciencegrid.org> requesting that your CE receive
+COVID-19 pilots.  We will need to know the CE hostname and any special
+restrictions that might apply to these pilots.
+
+Setting up a COVID-19 Job Route
+-------------------------------
+
+By default, COVID-19 pilots will look identical to OSG pilots _except_ they
+will have the attribute =IsCOVID19 = true=.  They do not require mapping to
+a distinct Unix account but can be sent to a prioritized queue or accounting
+group.
+
+Job routes are controlled by the `JOB_ROUTER_ENTRIES` configuration variable
+in HTCondor-CE (customizations may be placed in `/etc/condor-ce/config.d/`).
+
+For example, consider the following route for a CE submitting to a SLURM batch
+system:
+
+```
+JOB_ROUTER_ENTRIES @=jre
+[
+ name = "OSG Jobs";
+ GridResource = "batch slurm";
+ TargetUniverse = 9;
+ queue = "osg";
+]
+```
+
+To add a new route for COVID-19 pilots, append a new route
+prior to the existing one:
+
+```
+JOB_ROUTER_ENTRIES @=jre
+[
+ name = "OSG Jobs";
+ GridResource = "batch slurm";
+ TargetUniverse = 9;
+ queue = "covid19";
+ Requirements = (TARGET.IsCOVID19 =?= true);
+]
+[
+ name = "OSG Jobs";
+ GridResource = "batch slurm";
+ TargetUniverse = 9;
+ queue = "osg";
+]
+@jre
+```
+
+To verify jobs are being routed appropriately,
+[one may examine pilots](compute-element/troubleshoot-htcondor-ce/#condor_ce_router_q)
+with `condor_ce_router_q`.
+
+!!! note "Additional considerations for older CEs"
+    Prior to HTCondor 8.7.1, HTCondor-CE had separate rules for handling
+    multiple routes; see the
+    [job router recipes](/compute-element/job-router-recipes) for more
+    details.
+
+Similarly, at a HTCondor site, one can place these jobs into a
+separate accounting group by providing the `set_AcctGroup` attribute:
+
+```hl_lines="6"
+JOB_ROUTER_ENTRIES @=jre
+[
+ name = "OSG Jobs";
+ GridResource = "batch slurm";
+ TargetUniverse = 9;
+ set_AcctGroup = "covid19";
+ Requirements = (TARGET.IsCOVID19 =?= true);
+]
+[
+ name = "OSG Jobs";
+ TargetUniverse = 5;
+ queue = "osg";
+]
+@jre
+```
+
+Getting Help
+------------
+
+To get assistance, please use the [this page](/common/help).

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -41,7 +41,7 @@ system:
 ```
 JOB_ROUTER_ENTRIES @=jre
 [
- name = "OSG Jobs";
+ name = "OSG_Jobs";
  GridResource = "batch slurm";
  TargetUniverse = 9;
  queue = "osg";
@@ -49,54 +49,59 @@ JOB_ROUTER_ENTRIES @=jre
 ```
 
 To add a new route for COVID-19 pilots, append a new route
-prior to the existing one:
+prior to the existing one and specify their order:
 
-```
+```hl_lines="2 3 4 5 6 7 8 17 18"
 JOB_ROUTER_ENTRIES @=jre
 [
- name = "OSG COVID-19 Jobs";
+ name = "OSG_COVID-19_Jobs";
  GridResource = "batch slurm";
  TargetUniverse = 9;
  queue = "covid19";
  Requirements = (TARGET.IsCOVID19 =?= true);
 ]
 [
- name = "OSG Jobs";
+ name = "OSG_Jobs";
  GridResource = "batch slurm";
  TargetUniverse = 9;
  queue = "osg";
 ]
 @jre
+
+# Specify the order of the routes
+JOB_ROUTER_ROUTE_NAMES = OSG_COVID-19_Jobs, OSG_Jobs
 ```
 
 To verify jobs are being routed appropriately,
-[one may examine pilots](compute-element/troubleshoot-htcondor-ce/#condor_ce_router_q)
+[one may examine pilots](/compute-element/troubleshoot-htcondor-ce/#condor_ce_router_q)
 with `condor_ce_router_q`.
 
 !!! note "Additional considerations for older CEs"
-    Prior to HTCondor 8.7.1, HTCondor-CE had separate rules for handling
+    Prior to HTCondor 8.8.7 or 8.9.5, HTCondor-CE had separate rules for handling
     multiple routes; see the
-    [job router recipes](/compute-element/job-router-recipes) for more
+    [job router recipes](/compute-element/job-router-recipes#how-jobs-match-to-job-routes) for more
     details.
 
 Similarly, at a HTCondor site, one can place these jobs into a
 separate accounting group by providing the `set_AcctGroup` attribute:
 
-```hl_lines="6"
+```hl_lines="5 11"
 JOB_ROUTER_ENTRIES @=jre
 [
- name = "OSG COVID-19 Jobs";
- GridResource = "batch slurm";
- TargetUniverse = 9;
+ name = "OSG_COVID-19_Jobs";
+ TargetUniverse = 5;
  set_AcctGroup = "covid19";
  Requirements = (TARGET.IsCOVID19 =?= true);
 ]
 [
- name = "OSG Jobs";
+ name = "OSG_Jobs";
  TargetUniverse = 5;
- queue = "osg";
+ set_AcctGroup = "osg";
 ]
 @jre
+
+# Specify the order of the routes
+JOB_ROUTER_ROUTE_NAMES = OSG_COVID-19_Jobs, OSG_Jobs
 ```
 
 Only Supporting COVID-19
@@ -104,7 +109,7 @@ Only Supporting COVID-19
 
 If your resource _only_ wants to support COVID-19 research, then you need
 to [enable the OSG VO](/security/lcmaps-voms-authentication/#configuring-the-lcmaps-voms-plugin)
-but only provide the "OSG COVID-19 Jobs" job route above.  As long as the
+but only provide the `OSG_COVID-19_Jobs` job route above.  As long as the
 `Requirements` expression for your job route includes
 `(TARGET.IsCOVID19 =?= true)`, then non-COVID pilots will not be routed
 to the batch system.

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -16,7 +16,8 @@ instance or asking OSG to [host the CE](/compute-element/hosted-ce/) on your
 behalf.  If neither solution is viable, please send email to
 <help@opensciencegrid.org> and we can provide consulting services to determine
 a better approach.
-2. Enable the OSG VO and setup a job route specific to COVID-19 pilot jobs.
+2. [Enable the OSG VO](/security/lcmaps-voms-authentication/#configuring-the-lcmaps-voms-plugin)
+and setup a job route specific to COVID-19 pilot jobs.
 This process is documented below.  This enables you to prioritize these jobs
 according to your local policy.
 3. Send email to <help@opensciencegrid.org> requesting that your CE receive
@@ -53,7 +54,7 @@ prior to the existing one:
 ```
 JOB_ROUTER_ENTRIES @=jre
 [
- name = "OSG Jobs";
+ name = "OSG COVID-19 Jobs";
  GridResource = "batch slurm";
  TargetUniverse = 9;
  queue = "covid19";
@@ -84,7 +85,7 @@ separate accounting group by providing the `set_AcctGroup` attribute:
 ```hl_lines="6"
 JOB_ROUTER_ENTRIES @=jre
 [
- name = "OSG Jobs";
+ name = "OSG COVID-19 Jobs";
  GridResource = "batch slurm";
  TargetUniverse = 9;
  set_AcctGroup = "covid19";
@@ -97,6 +98,19 @@ JOB_ROUTER_ENTRIES @=jre
 ]
 @jre
 ```
+
+Only Supporting COVID-19
+------------------------
+
+If your resource _only_ wants to support COVID-19 research, then you need
+to [enable the OSG VO](/security/lcmaps-voms-authentication/#configuring-the-lcmaps-voms-plugin)
+but only provide the "OSG COVID-19 Jobs" job route above.  As long as the
+`Requirements` expression for your job route includes
+`(TARGET.IsCOVID19 =?= true)`, then non-COVID pilots will not be routed
+to the batch system.
+
+When you contact <help@opensciencegrid.org> to receive COVID-19 pilots,
+please note that you _only_ want to support these jobs.
 
 Getting Help
 ------------

--- a/docs/compute-element/job-router-recipes.md
+++ b/docs/compute-element/job-router-recipes.md
@@ -58,10 +58,17 @@ If the job only meets one route's requirements, the job is matched to that route
 If the job meets the requirements of multiple routes,  the route that is chosen depends on your version of HTCondor
 (`condor_version`):
 
-| If your version of HTCondor is... | Then the route is chosen by...                                                                                               |
-|-----------------------------------|------------------------------------------------------------------------------------------------------------------------------|
-| < 8.7.1                           | **Round-robin** between all matching routes. In this case, we recommend making each route's requirements mutually exclusive. |
-| >= 8.7.1                          | **First matching route** where routes are considered in the same order that they are configured                              |
+| If your version of HTCondor is...          | Then the route is chosen by...                                                                                                                                                                                   |
+|--------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| < 8.7.1                                    | **Round-robin** between all matching routes. In this case, we recommend making each route's requirements mutually exclusive.                                                                                     |
+| >= 8.7.1 and < 8.8.7, >= 8.9.0 and < 8.9.5 | **First matching route** where routes are considered in hash-table order. In this case, we recommend making each route's requirements mutually exclusive.                                                        |
+| >= 8.8.7, >= 8.9.5                         | **First matching route** where routes are considered in the order specified by [JOB_ROUTER_ROUTE_NAMES](https://htcondor.readthedocs.io/en/latest/admin-manual/configuration-macros.html#JOB_ROUTER_ROUTE_NAMES) |
+
+!!! bug "Job Route Order"
+    For HTCondor versions < 8.8.7 (as well as versions >= 8.9.0 and < 8.9.5) the order of job routes does not match the
+    order in which they are configured.
+    As a result, we recommend updating to at least HTCondor 8.9.5 (or 8.8.6) and specifying the names of your routes in
+    `JOB_ROUTER_ROUTE_NAMES` in the order that you'd like them considered.
 
 If you're using HTCondor >= 8.7.1 and would like to use round-robin matching, add the following text to a file in
 `/etc/condor-ce/config.d/`:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ pages:
   - 'Job Router Recipes': 'compute-element/job-router-recipes.md'
   - 'Troubleshooting HTCondor-CE': 'compute-element/troubleshoot-htcondor-ce.md'
   - 'Submitting to HTCondor-CE': 'compute-element/submit-htcondor-ce.md'
+  - 'Supporting COVID-19 Research': 'compute-element/covid-19.md'
 - Worker Node:
   - 'Overview': 'worker-node/using-wn.md'
   - 'Install from RPM': 'worker-node/install-wn.md'


### PR DESCRIPTION
This is the initial documentation for site admins to accept COVID-19 jobs.

To avoid potential authentication issues, this keeps things separate from VOMS and takes a job router-based approach.