### PR TITLE
Add COVID-19 routes instead of replacing existing routes

### DIFF
--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -38,7 +38,7 @@ Customizations may be placed in `/etc/condor-ce/config.d/` where files are parse
 
 To add a new route for COVID-19 pilots for non-HTCondor batch systems:
 
-1.  Note the names of your currently configured routes:
+1.  Note the names of your currently enabled routes:
 
         condor_ce_job_router_info -config
 
@@ -109,7 +109,7 @@ Similarly, at an HTCondor site, one can place these jobs into a separate account
 `set_AcctGroup` and `eval_set_AccountingGroup` attributes in a new job route.
 To add a new route for COVID-19 pilots for non-HTCondor batch systems:
 
-1.  Note the names of your currently configured routes:
+1.  Note the names of your currently enabled routes:
 
         :::console
         condor_ce_job_router_info -config
@@ -177,7 +177,7 @@ Verifying the COVID-19 Job Route
 
 To verify that your HTCondor-CE is configured to support COVID-19 jobs, perform the following steps:
 
-1.  Ensure that the `OSG_COVID19_Jobs` route appears with all of your other previously configured routes:
+1.  Ensure that the `OSG_COVID19_Jobs` route appears with all of your other previously enabled routes:
 
         :::console
         condor_ce_job_router_info -config

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -40,7 +40,7 @@ To add a new route for COVID-19 pilots for non-HTCondor batch systems:
 
 1.  Note the names of your currently configured routes:
 
-        condor_ce_job_router_info -config | awk '/^Name/ {print $3}
+        condor_ce_job_router_info -config
 
 1.  Add the following configuration to a file in `/etc/condor-ce/config.d/` (files are parsed in lexicographical order):
 
@@ -111,7 +111,7 @@ To add a new route for COVID-19 pilots for non-HTCondor batch systems:
 1.  Note the names of your currently configured routes:
 
         :::console
-        condor_ce_job_router_info -config | awk '/^Name/ {print $3}
+        condor_ce_job_router_info -config
 
 1.  Add the following configuration to a file in `/etc/condor-ce/config.d/` (files are parsed in lexicographical order):
 
@@ -175,7 +175,7 @@ To verify that your HTCondor-CE is configured to support COVID-19 jobs, perform 
 1.  Ensure that the `OSG_COVID19_Jobs` route appears with all of your other previously configured routes:
 
         :::console
-        condor_ce_job_router_info -config | awk '/^Name/ {print $3}
+        condor_ce_job_router_info -config
 
 
     !!! bug "Known issue: removing old routes"

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -10,19 +10,16 @@ from other OSG activity.
 
 To support this work, one must:
 
-1. Make the site computing resources available through a HTCondor-CE.  This
-can be done through an [on-premise](/compute-element/install-htcondor-ce/)
-instance or asking OSG to [host the CE](/compute-element/hosted-ce/) on your
-behalf.  If neither solution is viable, please send email to
-<help@opensciencegrid.org> and we can provide consulting services to determine
-a better approach.
-2. [Enable the OSG VO](/security/lcmaps-voms-authentication/#configuring-the-lcmaps-voms-plugin)
-and setup a job route specific to COVID-19 pilot jobs.
-This process is documented below.  This enables you to prioritize these jobs
-according to your local policy.
-3. Send email to <help@opensciencegrid.org> requesting that your CE receive
-COVID-19 pilots.  We will need to know the CE hostname and any special
-restrictions that might apply to these pilots.
+1. Make the site computing resources available through a HTCondor-CE.
+   This can be done through an [on-premise](/compute-element/install-htcondor-ce/) instance or asking OSG to
+   [host the CE](/compute-element/hosted-ce/) on your behalf.
+   If neither solution is viable, please send email to <help@opensciencegrid.org> and we can provide consulting
+   services to determine a better approach.
+1. [Enable the OSG VO](/security/lcmaps-voms-authentication/#configuring-the-lcmaps-voms-plugin) on your HTCondor-CE.
+1. Setup a job route specific to COVID-19 pilot jobs (documented below).
+   This enables you to prioritize these jobs according to your local policy.
+1. Send email to <help@opensciencegrid.org> requesting that your CE receive COVID-19 pilots.
+   We will need to know the CE hostname and any special restrictions that might apply to these pilots.
 
 Setting up a COVID-19 Job Route
 -------------------------------

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -56,7 +56,8 @@ To add a new route for COVID-19 pilots for non-HTCondor batch systems:
         $(JOB_ROUTER_ENTRIES)
         @jre
 
-    Replacing `slurm` in the `GridResource` attribute with the appropriate value for your batch system (`pbs`, `sge`, or `lsf`);
+    Replacing `slurm` in the `GridResource` attribute with the appropriate value for your batch system (e.g., `pbs`,
+    `sge`, or `lsf`);
     and the value of `queue` with the name of the partition or queue of your local batch system dedicated to COVID-19 work.
 
 1.  Ensure that COVID-19 jobs match to the new route.

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -56,8 +56,8 @@ To add a new route for COVID-19 pilots for non-HTCondor batch systems:
         $(JOB_ROUTER_ENTRIES)
         @jre
 
-    Replacing `slurm` in the `GridResource` attribute with the appropriate value for your batch system (e.g., `pbs`,
-    `sge`, or `lsf`);
+    Replacing `slurm` in the `GridResource` attribute with the appropriate value for your batch system (e.g., `lsf`,
+    `pbs`, `sge`, or `slurm`);
     and the value of `queue` with the name of the partition or queue of your local batch system dedicated to COVID-19 work.
 
 1.  Ensure that COVID-19 jobs match to the new route.

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -105,7 +105,7 @@ To add a new route for COVID-19 pilots for non-HTCondor batch systems:
 ### For HTCondor batch systems
 
 Similarly, at an HTCondor site, one can place these jobs into a separate accounting group by providing the
-`set_AcctGroup` attribute in a new job route.
+`set_AcctGroup` and `eval_set_AccountingGroup` attributes in a new job route.
 To add a new route for COVID-19 pilots for non-HTCondor batch systems:
 
 1.  Note the names of your currently configured routes:
@@ -115,16 +115,20 @@ To add a new route for COVID-19 pilots for non-HTCondor batch systems:
 
 1.  Add the following configuration to a file in `/etc/condor-ce/config.d/` (files are parsed in lexicographical order):
 
-        :::config hl_lines="5"
+        :::config hl_lines="5 6"
         JOB_ROUTER_ENTRIES @=jre
         [
          name = "OSG_COVID19_Jobs";
          TargetUniverse = 5;
          set_AcctGroup = "covid19";
+         eval_set_AccountingGroup = strcat(AcctGroup, ".", Owner);
          Requirements = (TARGET.IsCOVID19 =?= true);
         ]
         $(JOB_ROUTER_ENTRIES)
         @jre
+
+    Replacing `covid19` in `set_AcctGroup` with the name of the accounting group that you would like to use for COVID-19
+    jobs.
 
 1.  Ensure that COVID-19 jobs match to the new route.
     Choose one of the options below depending on your HTCondor version (`condor_version`):

--- a/docs/compute-element/covid-19.md
+++ b/docs/compute-element/covid-19.md
@@ -201,7 +201,8 @@ To verify that your HTCondor-CE is configured to support COVID-19 jobs, perform 
 Requesting COVID-19 Jobs
 ------------------------
 
-Contact <help@opensciencegrid.org> with the following information to receive COVID-19 pilot jobs:
+To receive COVID-19 pilot jobs, send an email to <help@opensciencegrid.org> with the subject `Requesting COVID-19 pilots`
+and the following information:
 
 -  Whether you want to receive _only_ COVID-19 jobs, or if you want to accept COVID-19 and other OSG jobs
 -  The hostname(s) of your HTCondor-CE(s)


### PR DESCRIPTION
This will help avoid the issue that Mats ran into where he removed his old route name and the job router crashed because of old jobs associated with the old route.

We may actually be able to get rid of the `Only supporting COVID-19` jobs section (or clarify it) since they can just copy the exact same configuration from above that's appropriate for their batch system.