### PR TITLE
Enable the metadata plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,5 +195,6 @@ markdown_extensions:
   - admonition
   - codehilite:
       guess_lang: False
+  - meta
   - toc:
       permalink: True


### PR DESCRIPTION
So that we can date reviews:

https://opensciencegrid.org/technology/documentation/reviewing-documentation/