### PR TITLE
Fixup StashCache container names in the ToC and headers

### DIFF
--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -1,5 +1,5 @@
-Running Stash Origin in a Container
-===================================
+Running StashCache Origin in a Container
+========================================
 
 The OSG operates the [StashCache data federation](/data/stashcache/overview), which
 provides organizations with a method to distribute their data in a scalable manner to thousands of jobs without needing

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -1,5 +1,5 @@
-Running Stashcache in a Container
-=================================
+Running StashCache Cache in a Container
+=======================================
 
 The OSG operates the [StashCache data federation](/data/stashcache/overview), which
 provides organizations with a method to distribute their data in a scalable manner to thousands of jobs without needing

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,10 +47,10 @@ pages:
     - 'Install CMS Xcache': 'data/xrootd/install-cms-xcache.md'
   - StashCache:
     - 'StashCache Overview': 'data/stashcache/overview.md'
-    - 'Running StashCache Cache in a container': 'data/stashcache/run-stashcache-container.md'
-    - 'Running StashCache Origin in a container': 'data/stashcache/run-stash-origin-container.md'
-    - 'Install StashCache Cache': 'data/stashcache/install-cache.md'
-    - 'Install StashCache Origin': 'data/stashcache/install-origin.md'
+    - 'Running a Cache in a container': 'data/stashcache/run-stashcache-container.md'
+    - 'Running an Origin in a container': 'data/stashcache/run-stash-origin-container.md'
+    - 'Install a Cache': 'data/stashcache/install-cache.md'
+    - 'Install an Origin': 'data/stashcache/install-origin.md'
     - 'Getting VO data into StashCache': 'data/stashcache/vo-data.md'
   - HDFS:
     - 'HDFS Overview': 'data/hadoop-overview.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,8 +47,8 @@ pages:
     - 'Install CMS Xcache': 'data/xrootd/install-cms-xcache.md'
   - StashCache:
     - 'StashCache Overview': 'data/stashcache/overview.md'
-    - 'Running Stashcache in a container': 'data/stashcache/run-stashcache-container.md'
-    - 'Running Stash origin in a container': 'data/stashcache/run-stash-origin-container.md'
+    - 'Running StashCache Cache in a container': 'data/stashcache/run-stashcache-container.md'
+    - 'Running StashCache Origin in a container': 'data/stashcache/run-stash-origin-container.md'
     - 'Install StashCache Cache': 'data/stashcache/install-cache.md'
     - 'Install StashCache Origin': 'data/stashcache/install-origin.md'
     - 'Getting VO data into StashCache': 'data/stashcache/vo-data.md'


### PR DESCRIPTION
All of these names are unfortunate but it is what it is.

Though maybe we should just update the doc ToC and headers to:

```
Data
  StashCache
    Running a Cache in a container
    Running an Origin in a container
    Install a Cache
    Install an Origin
```