### PR TITLE
Set default origin export (SOFTWARE-4138)

### DIFF
--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -69,6 +69,9 @@ user@host $ docker run --rm --publish 1094:1094 \
              opensciencegrid/stash-origin:stable
 ```
 
+!!!warning
+    A container deployed this way will serve the entire contents of `<HOST PARTITION>`.
+
 It is recommended to use a container orchestration service such as [docker-compose](https://docs.docker.com/compose/) or
 [kubernetes](https://kubernetes.io/), or start the stash origin container with systemd.
 

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -21,6 +21,8 @@ to start containers (i.e., belong to the `docker` Unix group).
 1. **Network ports:** The Stash Origin listens for incoming HTTP/S and XRootD connections on ports 1094 and 1095 (by
 default).
 1. **File Systems:** Stash Origin needs a partition on the host to store user data.
+1. **Registration:** Before deploying an origin, you must
+   [registered the service](/data/stashcache/install-origin/#registering-the-origin) in the OSG Topology
 
 Configuring Stash Origin
 ------------------------
@@ -34,23 +36,6 @@ Where the environment file on the docker host, `/opt/origin/.env`, has (at least
 
 ```file
 XC_RESOURCENAME=YOUR_SITE_NAME
-```
-
-### Creating an Auth File ###
-
-XRootD needs an authorization file ([AuthFile](/data/xrootd/xrootd-authorization/)) to control access to different parts
-of the namespace in your origin.
-You can create a simple authfile named `/opt/origin/auth_file` as follows:
-
-```file
-u * /origin rl
-```
-
-Create a configuration file for XRootD to find your authfile.
-Create a file `/opt/origin/10-origin-authfile.cfg`:
-
-```
-set StashOriginPublicAuthfile = /etc/xrootd/public-origin-authfile
 ```
 
 Running an Origin

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -33,7 +33,6 @@ Where the environment file on the docker host, `/opt/origin/.env`, has (at least
 [registered in Topology](/data/stashcache/install-origin/#registering-the-origin)):
 
 ```file
-XC_ORIGINEXPORT=/origin
 XC_RESOURCENAME=YOUR_SITE_NAME
 ```
 
@@ -53,7 +52,6 @@ Create a file `/opt/origin/10-origin-authfile.cfg`:
 ```
 set StashOriginPublicAuthfile = /etc/xrootd/public-origin-authfile
 ```
-
 
 Running an Origin
 -----------------


### PR DESCRIPTION
Also, remove the instructions for using a custom authfile. Deployed origins and caches should always get their authfiles from the Topology service. Submitting this as a draft PR since we need to verify that the latest `fresh` tag works as expected