### PR TITLE
Document prescribed locations for Stash Cache containers (SOFTWARE-4203)

### DIFF
--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -20,9 +20,7 @@ Before starting the installation process, consider the following points:
 to start containers (i.e., belong to the `docker` Unix group).
 1. **Network ports:** The Stash Origin listens for incoming HTTP/S and XRootD connections on ports 1094 and 1095 (by
 default).
-1. **File Systems:** Stash Origin needs host partitions to store user data.
-   For improved performance and storage, we recommend multiple partitions for handling namespaces (HDD), data (HDDs),
-   and metadata (SSDs).
+1. **File Systems:** Stash Origin needs a host partition to store user data.
 1. **Registration:** Before deploying an origin, you must
    [registered the service](/data/stashcache/install-origin/#registering-the-origin) in the OSG Topology
 
@@ -43,41 +41,10 @@ XC_RESOURCENAME=YOUR_SITE_NAME
 Running an Origin
 -----------------
 
-StashCache origin containers may be run with either multiple mounted host partitions (recommended) or a single host
-partition.
-
 It is recommended to use a container orchestration service such as [docker-compose](https://docs.docker.com/compose/)
 or [kubernetes](https://kubernetes.io/) whose details are beyond the scope of this document.
 The following sections provide examples for starting origin containers from the command-line as well as a more
 production-appropriate method using systemd.
-
-### Multiple host partitions (recommended) ###
-
-For improved performance and storage,
-especially if your origin is serving over 10 TB of data,
-we recommend multiple partitions for handling namespaces (HDD, SSD, or NVME), data (HDDs), and metadata (SSDs or NVME).
-
-```console
-user@host $ docker run --rm --publish 1094:1094 \
-             --publish 1095:1095 \
-             --volume <NAMESPACE PARTITION>:/xcache/namespace \
-             --volume <METADATA PARTITION 1>:/xcache/meta1
-             ...
-             --volume <METADATA PARTITION N>:/xcache/metaN
-             --volume <DATA PARTITION 1>:/xcache/data1
-             ...
-             --volume <DATA PARTITION N>:/xcache/dataN
-             --env-file=/opt/origin/.env \
-             opensciencegrid/stash-origin:fresh
-```
-
-!!! warning
-    For over 100 TB of assigned space we highly encourage to use this setup and mount `<NAMESPACE PARTITION>` in
-    solid state disks or NVME.
-
-### Single host partition ###
-
-For a simpler installation, you may use a single host partition mounted to `/xcache/`:
 
 ```console
 user@host $ docker run --rm --publish 1094:1094 \

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -63,7 +63,7 @@ production-appropriate method using systemd.
 ```console
 user@host $ docker run --rm --publish 1094:1094 \
              --publish 1095:1095 \
-             --volume <HOST PARTITION>:/xcache \
+             --volume <HOST PARTITION>:/xcache/namespace \
              --env-file=/opt/origin/.env \
              opensciencegrid/stash-origin:fresh
 ```
@@ -93,7 +93,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %n
 ExecStartPre=-/usr/bin/docker rm %n
 ExecStartPre=/usr/bin/docker pull opensciencegrid/stash-origin:fresh
-ExecStart=/usr/bin/docker run --rm --name %n -p 1094:1094 -p 1095:1095 -v /srv/origin:/xcache --env-file /opt/origin/.env opensciencegrid/stash-origin:fresh
+ExecStart=/usr/bin/docker run --rm --name %n -p 1094:1094 -p 1095:1095 -v /srv/origin:/xcache/namespace --env-file /opt/origin/.env opensciencegrid/stash-origin:fresh
 
 [Install] 
 WantedBy=multi-user.target

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -38,6 +38,20 @@ Where the environment file on the docker host, `/opt/origin/.env`, has (at least
 XC_RESOURCENAME=YOUR_SITE_NAME
 ```
 
+Populating Origin Data
+----------------------
+
+The Stash Cache data federation namespace is shared by multiple VOs so you must
+[choose a namespace](/data/stashcache/vo-data#choosing-namespace) for your own VO's data.
+When running an origin container, your chosen namespace must be reflected in your host partition.
+For example, if your host partition is `/srv/origin` and the name of your VO is `ASTRO`, you should create the following
+directories:
+
+- `/srv/origin/astro/PUBLIC`
+- `/srv/origin/astro/PROTECTED`
+
+When starting container, you will mount `/srv/origin/` into the container.
+
 Running an Origin
 -----------------
 

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -24,8 +24,8 @@ default).
 1. **Registration:** Before deploying an origin, you must
    [registered the service](/data/stashcache/install-origin/#registering-the-origin) in the OSG Topology
 
-Configuring Stash Origin
-------------------------
+Configuring the Origin
+----------------------
 
 In addition to the required configuration above (ports and file systems), you may also configure the behavior of your
 origin with the following variables using an environment variable file:
@@ -52,8 +52,8 @@ directories:
 
 When starting container, you will mount `/srv/origin/` into the container.
 
-Running an Origin
------------------
+Running the Origin
+------------------
 
 It is recommended to use a container orchestration service such as [docker-compose](https://docs.docker.com/compose/)
 or [kubernetes](https://kubernetes.io/) whose details are beyond the scope of this document.

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -46,27 +46,38 @@ Running an Origin
 StashCache origin containers may be run with either multiple mounted host partitions (recommended) or a single host
 partition.
 
+It is recommended to use a container orchestration service such as [docker-compose](https://docs.docker.com/compose/)
+or [kubernetes](https://kubernetes.io/) whose details are beyond the scope of this document.
+The following sections provide examples for starting origin containers from the command-line as well as a more
+production-appropriate method using systemd.
+
+
 !!!important "Partition ownership"
     Host partitions mounted into the StashCache origin container must be owned `10940:10940`
 
 ### Multiple host partitions (recommended) ###
 
-For improved performance and storage, we recommend multiple partitions for handling namespaces (HDD), data (HDDs),
-and metadata (SSDs).
+For improved performance and storage,
+especially if your origin is serving over 10 TB of data,
+we recommend multiple partitions for handling namespaces (HDD, SSD, or NVME), data (HDDs), and metadata (SSDs or NVME).
 
 ```console
 user@host $ docker run --rm --publish 1094:1094 \
              --publish 1095:1095 \
-             --volume <HDD NAMESPACE PARTITION>:/xcache/namespace \
-             --volume <SSD METADATA PARTITION 1>:/xcache/meta1
+             --volume <NAMESPACE PARTITION>:/xcache/namespace \
+             --volume <METADATA PARTITION 1>:/xcache/meta1
              ...
-             --volume <SSD METADATA PARTITION N>:/xcache/metaN
-             --volume <HDD DATA PARTITION 1>:/xcache/data1
+             --volume <METADATA PARTITION N>:/xcache/metaN
+             --volume <DATA PARTITION 1>:/xcache/data1
              ...
-             --volume <HDD DATA PARTITION N>:/xcache/dataN
+             --volume <DATA PARTITION N>:/xcache/dataN
              --env-file=/opt/origin/.env \
              opensciencegrid/stash-origin:fresh
 ```
+
+!!! warning
+    For over 100 TB of assigned space we highly encourage to use this setup and mount `<NAMESPACE PARTITION>` in
+    solid state disks or NVME.
 
 ### Single host partition ###
 
@@ -82,9 +93,6 @@ user@host $ docker run --rm --publish 1094:1094 \
 
 !!!warning
     A container deployed this way will serve the entire contents of `<HOST PARTITION>`.
-
-It is recommended to use a container orchestration service such as [docker-compose](https://docs.docker.com/compose/) or
-[kubernetes](https://kubernetes.io/), or start the stash origin container with systemd.
 
 ### Running on origin container with systemd
 

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -51,10 +51,6 @@ or [kubernetes](https://kubernetes.io/) whose details are beyond the scope of th
 The following sections provide examples for starting origin containers from the command-line as well as a more
 production-appropriate method using systemd.
 
-
-!!!important "Partition ownership"
-    Host partitions mounted into the StashCache origin container must be owned `10940:10940`
-
 ### Multiple host partitions (recommended) ###
 
 For improved performance and storage,

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -144,7 +144,7 @@ root@host $ systemctl start docker.stash-cache
 
 ### Network optimization ###
 
-For caches that are connected to NIC's over `40Gbps` we recommend to disable the virtualized network and "bind" the
+For caches that are connected to NIC's over `40Gbps` we recommend that you disable the virtualized network and "bind" the
 container to the host network:
 
 ```console

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -140,13 +140,15 @@ root@host $ systemctl start docker.stash-cache
 ```
 
 !!! warning
-    You must [register](/data/stashcache/install-cache/#registering-the-cache) the cache before considering it a production service.
+    You must [register](/data/stashcache/install-cache/#registering-the-cache) the cache before considering it a
+    production service.
 
 
 
-### Network Optimization ###
+### Network optimization ###
 
-For caches that are connected to NIC's over `40Gbps` we recommend to disable the virtualized network and "bind" the container to the host network:
+For caches that are connected to NIC's over `40Gbps` we recommend to disable the virtualized network and "bind" the
+container to the host network:
 
 ```console
 user@host $ docker run --rm  \

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -20,7 +20,7 @@ Before starting the installation process, consider the following points:
 1. **Docker:** For the purpose of this guide, the host must have a running docker service
    and you must have the ability to start containers (i.e., belong to the `docker` Unix group).
 1. **Network ports:** Stash Cache listens for incoming HTTP/S connections on port 8000 (by default)
-1. **File Systems:** Stash Origin needs host partitions to store user data.
+1. **File Systems:** Stash Cache needs host partitions to store user data.
    For improved performance and storage, we recommend multiple partitions for handling namespaces (HDD), data (HDDs),
    and metadata (SSDs).
 
@@ -186,4 +186,3 @@ Getting Help
 ------------
 
 To get assistance, please use the [this page](/common/help) or contact <help@opensciencegrid.org> directly.
-

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -58,9 +58,6 @@ Running a Cache
 StashCache cache containers  may be run with either multiple mounted host partitions (recommended) or a single host
 partition.
 
-!!!important "Partition ownership"
-    Host partitions mounted into the StashCache origin container must be owned `10940:10940`
-
 It is recommended to use a container orchestration service such as [docker-compose](https://docs.docker.com/compose/)
 or [kubernetes](https://kubernetes.io/) whose details are beyond the scope of this document.
 The following sections provide examples for starting cache containers from the command-line as well as a more


### PR DESCRIPTION
Labeled as `do-not-merge` because the latest `stable` containers are still using the old config. @efajardo I could use a sanity checking review, though