### PR TITLE
Fix an issue with CVMFS mounts

### DIFF
--- a/docs/resource-sharing/os-backfill-containers.md
+++ b/docs/resource-sharing/os-backfill-containers.md
@@ -47,7 +47,7 @@ docker run -it --rm --user osg \
        --cap-add=DAC_OVERRIDE --cap-add=SETUID --cap-add=SETGID \
        --cap-add=SYS_ADMIN --cap-add=SYS_CHROOT --cap-add=SYS_PTRACE \
        --cap-add=CAP_DAC_READ_SEARCH \
-       -v /cvmfs:/cvmfs \
+       -v /cvmfs:/cvmfs:shared \
        -e TOKEN="..." \
        -e GLIDEIN_Site="..." \
        -e GLIDEIN_ResourceName="..." \


### PR DESCRIPTION
Noticed by Erik at Purdue

```
[osg@6fee62bc0aff cvmfs]$ cd /cvmfs/cms.cern.ch
bash: cd: /cvmfs/cms.cern.ch: Too many levels of symbolic links
```