### PR TITLE
Add HTCondor-CE 5 upgrade instructions to OSG-3.5

### DIFF
--- a/docs/release/3.5/release-3-5-36.md
+++ b/docs/release/3.5/release-3-5-36.md
@@ -27,7 +27,10 @@ This release contains:
 -   vault 1.7.1: Update to latest upstream release
 -   htvault-config 1.1: Uses yaml configuration files
 -   htgettoken 1.2: improved error message handling and bug fixes
--   Upcoming: [GlideinWMS 3.7.3](https://glideinwms.fnal.gov/doc.v3_7_3/history.html#development)
+-   Upcoming
+    -   [HTCondor-CE 5.1.0](https://github.com/htcondor/htcondor-ce/releases/tag/v5.1.0)
+        -   Please consult the [upgrade documentation](https://htcondor.github.io/htcondor-ce/v5/releases/#updating-to-htcondor-ce-5)
+    -   [GlideinWMS 3.7.3](https://glideinwms.fnal.gov/doc.v3_7_3/history.html#development)
 
 !!! bug "Known Issue"
     - GlideinWMS 3.7.3: submissions from 3.6.5 frontends to 3.7.3 factory go on hold

--- a/docs/release/3.5/release-3-5-36.md
+++ b/docs/release/3.5/release-3-5-36.md
@@ -28,7 +28,10 @@ This release contains:
 -   htvault-config 1.1: Uses yaml configuration files
 -   htgettoken 1.2: improved error message handling and bug fixes
 -   Upcoming
-    -   [HTCondor-CE 5.1.0](https://github.com/htcondor/htcondor-ce/releases/tag/v5.1.0)
+    -   [HTCondor-CE 5.1.0](https://htcondor.github.io/htcondor-ce/v5/releases/#510)
+        -   Support for Job Router Transform configuration syntax
+        -   Credential mapping changes
+        -   Converted to Python 3
         -   Please consult the [upgrade documentation](https://htcondor.github.io/htcondor-ce/v5/releases/#updating-to-htcondor-ce-5)
     -   [GlideinWMS 3.7.3](https://glideinwms.fnal.gov/doc.v3_7_3/history.html#development)
 

--- a/docs/release/notes.md
+++ b/docs/release/notes.md
@@ -24,7 +24,7 @@ To update to the OSG 3.5 series, please consult the page on
 
 | Version                             | Date       | Summary                                                                       |
 |:------------------------------------|:-----------|:------------------------------------------------------------------------------|
-| [3.5.36](3.5/release-3-5-36.md)     | 2021-05-17 | HTCondor 8.8.13; Upcoming: GlideinWMS 3.7.3                                   |
+| [3.5.36](3.5/release-3-5-36.md)     | 2021-05-17 | HTCondor 8.8.13; Upcoming: HTCondor 9.0.0-1.5, HTCondor-CE 5.1.0, GlideinWMS 3.7.3 |
 | [3.5.35](3.5/release-3-5-35.md)     | 2021-05-13 | High Priority Release: Frontier Squid 4.15-1.2, IGTF 1.110                    |
 | [3.5.34](3.5/release-3-5-34.md)     | 2021-04-22 | CVMFS 2.8.1, gratia-probe 1.23.2                                              |
 | [3.5.33](3.5/release-3-5-33.md)     | 2021-04-01 | Upcoming: XRootD 5.1.1 and plugins, XCache 2.0.0                              |

--- a/docs/release/updating-to-osg-35.md
+++ b/docs/release/updating-to-osg-35.md
@@ -141,7 +141,7 @@ To update OSG Configure on your HTCondor-CE, perform the following steps:
 
 1.  Set `resource_group` in `/etc/osg/config.d/40-siteinfo.ini` to the resource group registered in
     [OSG Topology](../common/registration.md#registering-resources),
-    i.e. the name of the `.yaml` file in OSG Topology that contains the registered resouce above.
+    i.e. the name of the `.yaml` file in OSG Topology that contains the registered resource above.
 
 1.  Set `host_name` to the host name that is registered in [OSG Topology](../common/registration.md#registering-resources).
     This may be different from the FQDN of the host if you're using a DNS alias, for example.
@@ -158,24 +158,7 @@ Updating to HTCondor-CE 5
     version upgrade from HTCondor-CE 4,
     is available through the [OSG upcoming](release_series.md) repository.
 
-To update HTCondor-CE, perform the following steps:
-
-1.  Merge any `*.rpmnew` files in `/etc/condor-ce/`
-
-1.  HTCondor-CE <= 4 set `$HOME` in the routed job to the user's `$HOME` directory on the HTCondor-CE but this is no
-    longer the default.
-    If you want to ensure that a routed job's `$HOME` is set to the same directory as the user on the CE,
-    set `USE_CE_HOME_DIR = True` in `/etc/condor-ce/config.d/`.
-
-!!! note "For OSG CEs serving an HTCondor pool"
-    If your OSG CE routes pilot jobs to a local HTCondor pool, also
-    see the section for [updating your HTCondor hosts](#updating-to-htcondor-900)
-
-After updating your RPMs and updating your configuration, turn on the HTCondor-CE service:
-
-```console
-root@host # systemctl start condor-ce
-```
+To update HTCondor-CE 5, consult the [upgrade documentation](https://htcondor.github.io/htcondor-ce/v5/releases/#updating-to-htcondor-ce-5)
 
 Updating to HTCondor 8.8.x
 --------------------------
@@ -197,7 +180,7 @@ To update HTCondor on your HTCondor-CE and/or HTCondor pool hosts, perform the f
       Additionally in OSG 3.5, the default security was changed to use FS and pool password.
       If you are experiencing issues with communication between hosts in your pool after the upgrade,
       the default OSG configuration is listed in `/etc/condor/config.d/00-osg_default_*.config`:
-      ensure that any default configuration is overriden with your own `DAEMON_LIST`, `CONDOR_HOST`, and/or
+      ensure that any default configuration is overridden with your own `DAEMON_LIST`, `CONDOR_HOST`, and/or
       [security](https://htcondor.readthedocs.io/en/v8_8/admin-manual/security.html) configuration in subsequent files.
 
     - As of HTCondor 8.8, [MOUNT\_UNDER\_SCRATCH](https://htcondor.readthedocs.io/en/v8_8/admin-manual/configuration-macros.html#condor-startd-configuration-file-macros)


### PR DESCRIPTION
Added the HTCondor-CE 5 section. Moved HTCondor 8.8.x section before HTCondor 9.0.0 section. (It's a more logical progression.)