### PR TITLE
Document the requirement for SSH multiplexing

### DIFF
--- a/docs/compute-element/hosted-ce.md
+++ b/docs/compute-element/hosted-ce.md
@@ -30,9 +30,10 @@ Before preparing your cluster for OSG resource requests, consider the following 
 -   An existing compute cluster with a [supported batch system](../index.md#contributing-to-the-osg)
     running on a [supported operating system](../release/supported_platforms.md)
 -   Outbound network connectivity from the worker nodes (they can be behind NAT)
--   One or more Unix accounts on your cluster's submit server,
-    accessible via SSH key and with remote port forwarding (`AllowTcpForwarding`) enabled,
-    with permissions to submit jobs to your local cluster.
+-   One or more Unix accounts on your cluster's submit server with the following capabilities:
+    -   Accessible via SSH key
+    -   Use of SSH remote port forwarding (`AllowTcpForwarding yes`) and SSH multiplexing (`MaxSessions 10`)
+    -   Permission to submit jobs to your local cluster.
 -   Shared user home directories between the submit server and the worker nodes.
     Not required for HTCondor clusters:
     see [this section](#htcondor-clusters-only-installing-the-osg-worker-node-client) for more details.

--- a/docs/compute-element/hosted-ce.md
+++ b/docs/compute-element/hosted-ce.md
@@ -32,7 +32,7 @@ Before preparing your cluster for OSG resource requests, consider the following 
 -   Outbound network connectivity from the worker nodes (they can be behind NAT)
 -   One or more Unix accounts on your cluster's submit server with the following capabilities:
     -   Accessible via SSH key
-    -   Use of SSH remote port forwarding (`AllowTcpForwarding yes`) and SSH multiplexing (`MaxSessions 10`)
+    -   Use of SSH remote port forwarding (`AllowTcpForwarding yes`) and SSH multiplexing (`MaxSessions 10` or greater)
     -   Permission to submit jobs to your local cluster.
 -   Shared user home directories between the submit server and the worker nodes.
     Not required for HTCondor clusters:


### PR DESCRIPTION
@jeffreynpeterson ran into an issue where the remote site set `MaxSessions=1` that resulted in jobs getting held and the following showed up in the GridmanagerLog (and maybe the hold reason?):

```
mux_client_request_session: session request failed: Session open refused by peer
```