### PR TITLE
Reenable search bar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,7 @@ markdown_extensions:
       permalink: True
 
 plugins:
+  - search
   - redirects:
       redirect_maps:
         site-responsibilities.md: site-maintenance.md


### PR DESCRIPTION
According to
https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#built-in-search,
the search plugin is enabled by default but must be re-added when
other plug-ins are used, like the redirect plugin