### PR TITLE
Update XRootD authZ doc for OSG 3.6 (SOFTWARE-4585)

### DIFF
--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -190,8 +190,8 @@ To validate an XRootD installation, perform the following verification steps:
     For example, if you are using a VOMS proxy,
     make sure your DN is mapped to a user in [/etc/grid-security/grid-mapfile](../../security/lcmaps-voms-authentication.md#mapping-users),
     and make sure you have a valid proxy on your local machine.
-    Also, ensure that the [Authfile](xrootd-authorization.md#authorization-file) on the XRootD server gives write access
-    to the Unix user you will get mapped to.
+    Also, ensure that the [Authfile](xrootd-authorization.md#authorization-database-file) on the XRootD server gives
+    write access to the Unix user you will get mapped to.
 
 1. Verify file transfer over the XRootD protocol using XRootD client tools:
 

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -190,7 +190,7 @@ To validate an XRootD installation, perform the following verification steps:
     For example, if you are using a VOMS proxy,
     make sure your DN is mapped to a user in [/etc/grid-security/grid-mapfile](../../security/lcmaps-voms-authentication.md#mapping-users),
     and make sure you have a valid proxy on your local machine.
-    Also, ensure that the [Authfile](xrootd-authorization.md#authorization-database-file) on the XRootD server gives
+    Also, ensure that the [Authfile](xrootd-authorization.md#authorization-database) on the XRootD server gives
     write access to the Unix user you will get mapped to.
 
 1. Verify file transfer over the XRootD protocol using XRootD client tools:

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -5,17 +5,10 @@ Configuring XRootD Authorization
     There is an incompatibility with EL7 < 7.5 due to an issue with the `globus-gsi-proxy-core` package
 
 XRootD offers several authentication options [security plugins](https://xrootd.slac.stanford.edu/doc/dev50/sec_config.htm)
-to validate incoming credentials, such as VOMS proxies or bearer tokens.
-After the incoming credential has been mapped to a user, the [Authorization Database File](#authorization-database-file)
-is used to provide fine-grained file access.
+to validate incoming credentials, such as bearer tokens, GSI proxies, and VOMS proxies.
 
-In OSG 3.5, XRootD installations depended on [LCMAPS](#lcmaps-authentication) to authenticate incoming VOMS proxies, so
-XRootD adminstrators must edit `/etc/grid-security/grid-mapfile` and `/etc/grid-security/voms-mapfile` as well as
-[Authorization Database File](#authorization-database-file) to control file access.
-
-In OSG 3.6, XRootD installations are automatically configured to authenticate all bearer tokens, macaroons, and VOMS
-proxies, so XRootD administrators can control file access solely through the
-[Authorization Database File](#authorization-database-file).
+In the case of GSI and VOMS proxies, after the incoming credential has been mapped to a username or groupname, the
+[authorization database file](#authorization-database-file) is used to provide fine-grained file access.
 
 !!! note
     On data nodes, files will be owned by Unix user `xrootd` (or other daemon user), not as the user
@@ -24,17 +17,89 @@ proxies, so XRootD administrators can control file access solely through the
     to, but, internally, the data node files will be owned by the `xrootd` user. If this behaviour is not desired, enable
     [XRootD multi-user support](install-standalone.md#enabling-multi-user-support). 
 
+Authentication
+--------------
+
+### OSG 3.6 ###
+
+In [OSG 3.6](#osg-3.6), XRootD installations are automatically configured to
+authenticate all bearer tokens, macaroons, and VOMS proxies, so XRootD administrators can control file access solely
+through the [Authorization Database File](#authorization-database-file).
+Optionally, you may map the subject distinguished names of incoming X.509 proxies to a user in
+`/etc/grid-security/grid-mapfile`.
+This mapped user can then be used in XRootD's Authorization Database file.
+
+#### Mapping X.509 proxies ####
+
+!!! note "DN mappings take precedence over VOMS attributes"
+    If you have mapped the subject DN of an incoming VOMS proxy, XRootD will map it to a username
+
+In OSG 3.6, X.509 proxies are mapped using the built-in XRootD GSI plug-in.
+To map an incoming proxy's subject DN to an [XRootD username](#formatting),
+add lines of the following format to `/etc/grid-security/grid-mapfile`:
+
+```
+"<SUBJECT DN>" <AUTHDB USERNAME>
+```
+
+Replacing `<SUBJECT DN>` with the X.509 proxy's DN to map and `<AUTHDB USERNAME>` with the username to reference in the
+[authorization database file](#formatting).
+For example, the following mapping:
+
+```
+"/DC=org/DC=cilogon/C=US/O=University of Wisconsin-Madison/CN=Brian Lin A2266246" blin
+```
+
+Will result in the username `blin`,
+i.e. authorize access to clients presenting the above proxy with `u blin ...` in the authorization database file.
+
+#### Mapping VOMS proxies ####
+
+!!! bug "VOMS attribute mappings incompatible with `xrootd-multiuser`"
+    The OSG 3.6 configuration of XRootD uses the `XrdVoms` plugin, which pass along the entire VOMS FQAN as the
+    groupname to the authorization layer (see the section on [authorization database file formatting](#formatting)).
+    Some characters in VOMS FQANs are not legal in Unix usernames, therefore VOMS attributes mappings are incompatible
+    with `xrootd-multiuser`.
+    See [XRootD GitHub issue #1538](https://github.com/xrootd/xrootd/issues/1538) for more details.
+
+In OSG 3.6, VOMS proxies are automatically mapped using the built-in XRootD GSI and VOMS plug-ins.
+An incoming VOMS proxy will authenticate the first VOMS FQAN to the [authorization database groupname](#formatting).
+For example, a VOMS proxy from the OSPool will be authenticated to the following groupname:
+
+`/osg/Role=NULL/Capability=NULL`
+
+Instead of only using the first VOMS FQAN, you can configure XRootD to consider all VOMS FQANs in the proxy for
+authentication by setting the following in `/etc/xrootd/config.d/10-osg-xrdvoms.cfg`:
+
+```
+set vomsfqans = useall
+```
+
+### OSG 3.5 ###
+
+!!! info "OSG 3.5 end-of-life"
+    OSG 3.5 will reach its end-of-life in [February 2022](../../release/release_series.md#series-overviews).
+
+In OSG 3.5, the [LCMAPS VOMS plugin](../../security/lcmaps-voms-authentication.md) is used to authenticate X.509 and
+VOMS proxies to usernames utilized by the [authorization database file](#formatting).
+Perform the following instructions on all data nodes:
+
+1.  Install [CA certificates](../../common/ca.md#installing-ca-certificates) and 
+    [manage CRLs](../../common/ca.md#managing-certificate-revocation-lists)
+
+1.  Copy your host certificate and key to `/etc/grid-security/xrd/xrdcert.pem` and `/etc/grid-security/xrd/xrdkey.pem`,
+    respectively.
+
+1.  Configure the [LCMAPS VOMS plugin](../../security/lcmaps-voms-authentication.md)
+
 Authorization Database File
 ---------------------------
 
-XRootD allows configuring fine-grained file access permissions based on usernames and paths.
-This is configured in the authorization file `/etc/xrootd/auth_file` on the data server node, which should be writable
-only by the xrootd user, optionally readable by others.
+XRootD allows configuring fine-grained file access permissions based on authenticated identities and paths.
+This is configured in the authorization file `/etc/xrootd/Authfile`, which should be writable
+only by the `xrootd` user, optionally readable by others.
 
-(The path `/etc/xrootd/auth_file` corresponds to the
-[`acc.authdb`](http://xrootd.org/doc/dev47/sec_config.htm#_Toc489606592) parameter in your xrootd config.)
-
-Here is an example `/etc/xrootd/auth_file` :
+Here is an example `/etc/xrootd/Authfile` :
 
 ```file hl_lines="2 5 8 13 16"
 # This means that all the users have read access to the datasets, _except_ under /private
@@ -51,8 +116,8 @@ u = <STORAGE PATH>/home/@=/ a
 # private dirs for users willing to store their data in the facility
 u xrootd <STORAGE PATH> a
 
-# This means that users in group 'biology' can do anything under the 'genomics' directory
-g biology <STORAGE PATH>/genomics a
+# This means that OSPool clients presenting a VOMS proxy can do anything under the 'osg' directory
+g /osg <STORAGE PATH>/osg a
 ```
 
 Replacing `<STORAGE PATH>` with the path to the directory that will contain data served by XRootD, e.g. `/data/xrootdfs`.
@@ -65,6 +130,8 @@ xrootd config file.
             u * rl /data/xrootdfs -rl /data/xrootdfs/private
 
 
+### Formatting ###
+
 More generally, each configuration line of the auth file has the following form:
 
 ``` file
@@ -73,7 +140,7 @@ idtype id path privs
 
 | Field  | Description                                                                                                                           |
 |--------|---------------------------------------------------------------------------------------------------------------------------------------|
-| idtype | Type of id. Use `u` for username, `g` for group, etc.                                                                                 |
+| idtype | Type of id. Use `u` for username, `g` for groupname, etc.                                                                             |
 | id     | Username (or groupname). Use `*` for all users or `=` for user-specific capabilities, like home directories                           |
 | path   | The path prefix to be used for matching purposes.  `@=` expands to the current user name before a path prefix match is attempted      |
 | privs  | Letter list of privileges: `a` - all ; `l` - lookup ; `d` - delete ; `n` - rename ; `i` - insert ; `r` - read ; `k` - lock (not used) ; `w` - write ; `-` - prefix to remove specified privileges |
@@ -81,40 +148,21 @@ idtype id path privs
 For more details or examples on how to use templated user options, see
 [XRootd Authorization Database File](http://xrootd.org/doc/dev47/sec_config.htm#_Toc489606599).
 
-Ensure the auth file is owned by `xrootd` (if you have created file as root), and that it is not writable by others.
+### Verifying file ownership and permissions ###
+
+Ensure the authorization datbase file is owned by `xrootd` (if you have created file as root),
+and that it is not writable by others.
 
 ```console
-root@host # chown xrootd:xrootd /etc/xrootd/auth_file
-root@host # chmod 0640 /etc/xrootd/auth_file  # or 0644
+root@host # chown xrootd:xrootd /etc/xrootd/Authfile
+root@host # chmod 0640 /etc/xrootd/Authfile  # or 0644
 ```
 
+Applying Authorization Changes
+------------------------------
 
-LCMAPS Authentication
----------------------
-
-!!! info "OSG 3.5 only"
-    LCMAPS-based authentication is only supported in OSG 3.5.
-
-The `xrootd-lcmaps` security plugin uses the LCMAPS library and the
-[LCMAPS VOMS plugin](../../security/lcmaps-voms-authentication.md) to authenticate and authorize users based on X.509
-certificates and VOMS attributes.
-Perform the following instructions on all data nodes:
-
-1. Install [CA certificates](../../common/ca.md#installing-ca-certificates) and [manage CRLs](../../common/ca.md#managing-certificate-revocation-lists)
-
-1. Copy your host certificate and key to `/etc/grid-security/xrd/xrdcert.pem` and `/etc/grid-security/xrd/xrdkey.pem`,
-   respectively.
-
-1. Install and configure the [LCMAPS VOMS plugin](../../security/lcmaps-voms-authentication.md)
-
-1. Install `xrootd-lcmaps` and necessary configuration:
-
-        :::console
-        root@host # yum install xrootd-lcmaps vo-client
-
-1. Configure access rights for mapped users by creating and modifying the XRootD [authorization file](#authorization-database-file)
-
-1. Restart the [relevant services](install-standalone.md#using-xrootd)
+After making changes to your [authorization database file](#authorization-database-file), you must restart the
+[relevant services](install-standalone.md#using-xrootd).
 
 Verifying XRootD Authorization
 ------------------------------

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -252,6 +252,34 @@ After making changes to your [authorization database](#authorization-database), 
 Verifying XRootD Authorization
 ------------------------------
 
+### Bearer tokens ###
+
+To test read access using macaroon, SciTokens, and WLCG token authorization, run the following command:
+
+```console
+user@ host $curl -v \
+                 -H 'Authorization: Bearer <TOKEN>' \
+                 https://host.example.com//path/to/directory/hello_world
+```
+
+Replacing `<TOKEN>` with the contents of your encoded token, `host.example.com` with the target XRootD host, and
+`/path/to/directory/hello_world` with the path of the file to read.
+
+
+To test write access, using macaroon, SciTokens, and WLCG token authorization, run the following command:
+
+```console
+user@ host $curl -v \
+                 -X PUT \
+                 --upload-file <FILE TO UPLOAD> \
+                 -H 'Authorization: Bearer <TOKEN>' \
+                 https://host.example.com//path/to/directory/hello_world
+```
+
+Replacing `<TOKEN>` with the contents of your encoded token, `<FILE TO UPLOAD>` with the file to write to the XRootD
+host, `host.example.com` with the target XRootD host, and `/path/to/directory/hello_world` with the path of the file to
+write.
+
 ### X.509 and VOMS proxies ###
 
 To verify X.509 and VOMS proxy authorization, run the following commands from a machine with your user certificate/key

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -43,7 +43,7 @@ To configure XRootD to accept tokens from a given token issuer use the following
 
 1.  **(Optional)** if you want to map the incoming token for a given issuer to a Unix username:
 
-    1.  Install [xrootd-multiuser](#install-standalone#enabling-multi-user-support)
+    1.  Install [xrootd-multiuser](install-standalone#enabling-multi-user-support)
 
     1.  Add the following to the relevant issuer section in `/etc/xrootd/scitokens.conf`:
 
@@ -98,7 +98,7 @@ Authorizing X.509 proxies
     with `xrootd-multiuser`.
     See [XRootD GitHub issue #1538](https://github.com/xrootd/xrootd/issues/1538) for more details.
 
-In [OSG 3.6](../../release/release_series#series-overviews), XRootD installations are automatically configured to
+In [OSG 3.6](../../release/release_series.md#series-overviews), XRootD installations are automatically configured to
 authenticate all X.509 and VOMS proxies, so XRootD administrators can control file access through the
 [authorization database](#authorization-database).
 Optionally, you may map the subject distinguished names of incoming X.509 proxies to a username in
@@ -157,7 +157,7 @@ set vomsfqans = useall
 !!! info "OSG 3.5 end-of-life"
     OSG 3.5 will reach its end-of-life in [February 2022](../../release/release_series.md#series-overviews).
 
-In [OSG 3.5](../../release/release_series#series-overviews), [LCMAPS](../../security/lcmaps-voms-authentication.md) is
+In [OSG 3.5](../../release/release_series.md#series-overviews), [LCMAPS](../../security/lcmaps-voms-authentication.md) is
 used to authenticate X.509 and VOMS proxies to usernames utilized by the
 [authorization database](#authorization-database).
 Perform the following instructions on all data nodes:

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -21,7 +21,8 @@ the permissions listed in the [authorization file](#authorization-file) all refe
     to, but, internally, the data node files will be owned by the `xrootd` user. If this behaviour is not desired, enable
     [XRootD multi-user support](install-standalone.md#enabling-multi-user-support). 
 
-#### Authorization file
+Authorization File
+------------------
 
 XRootD allows configuring fine-grained file access permissions based on usernames and paths.
 This is configured in the authorization file `/etc/xrootd/auth_file` on the data server node, which should be writable
@@ -85,7 +86,8 @@ root@host # chmod 0640 /etc/xrootd/auth_file  # or 0644
 ```
 
 
-#### Enabling xrootd-lcmaps authorization
+LCMAPS Authorization
+--------------------
 
 The xrootd-lcmaps security plugin uses the `lcmaps` library and the [LCMAPS VOMS plugin](../../security/lcmaps-voms-authentication.md)
 to authenticate and authorize users based on X509 certificates and VOMS attributes. Perform the following instructions

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -29,7 +29,7 @@ in the case of SciTokens and WLCG tokens, you may configure XRootD to further re
 ### Configuring SciTokens/WLCG Tokens ###
 
 SciTokens and WLCG Tokens are asymmetrically signed bearer tokens: they are signed by a token issuer (e.g., CILogon, IAM)
-and can be authenticated with the token issuer's public key.
+and can be verified with the token issuer's public key.
 To configure XRootD to accept tokens from a given token issuer use the following instructions:
 
 1.  Add a section for each token issuer to `/etc/xrootd/scitokens.conf`:
@@ -49,13 +49,13 @@ To configure XRootD to accept tokens from a given token issuer use the following
 
             map_subject = True
 
-1.  **(Optional)** if you want to only accept tokens with the appropriate `aud` field, the following to
+1.  **(Optional)** if you want to only accept tokens with the appropriate `aud` field, add the following to
     `/etc/xrootd/scitokens.conf`:
 
         [Global]
         audience = <COMMMA SEPARATED LIST OF AUDIENCES>
 
-An example configuration that supports the OSG Connect and CMS:
+An example configuration that supports tokens issued by the OSG Connect and CMS:
 
 ```
 [Global]
@@ -77,6 +77,7 @@ base_path = /user/cms
 
 Macaroons are symetrically signed bearer tokens so your XRootD host must have access to the same secret key that is used
 to sign incoming macaroons.
+When used in an XRootD cluster, all data nodes and the redirector need access to the same secret.
 To enable macaroon support:
 
 1.  Place the shared secret in `/etc/xrootd/macaroon-secret`

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -4,25 +4,28 @@ Configuring XRootD Authorization
 !!!bug "EL7 version compatibility"
     There is an incompatibility with EL7 < 7.5 due to an issue with the `globus-gsi-proxy-core` package
 
+XRootD offers several authentication options [security plugins](https://xrootd.slac.stanford.edu/doc/dev50/sec_config.htm)
+to validate incoming credentials, such as VOMS proxies or bearer tokens.
+After the incoming credential has been mapped to a user, the [Authorization Database File](#authorization-database-file)
+is used to provide fine-grained file access.
 
-There are several authorization options in XRootD available through its security plugins.
-In this document, we will cover the [`xrootd-lcmaps`](#enabling-xrootd-lcmaps-authorization) security option supported
-in the OSG.
+In OSG 3.5, XRootD installations depended on [LCMAPS](#lcmaps-authentication) to authenticate incoming VOMS proxies, so
+XRootD adminstrators must edit `/etc/grid-security/grid-mapfile` and `/etc/grid-security/voms-mapfile` as well as
+[Authorization Database File](#authorization-database-file) to control file access.
 
-The XRootD LCMAPS authorization method depends on configuring
-[LCMAPS with the VOMS plugin](../../security/lcmaps-voms-authentication.md).
-LCMAPS maps an incoming user's grid credentials to a Unix account name;
-the permissions listed in the [authorization file](#authorization-file) all reference Unix account names. 
+In OSG 3.6, XRootD installations are automatically configured to authenticate all bearer tokens, macaroons, and VOMS
+proxies, so XRootD administrators can control file access solely through the
+[Authorization Database File](#authorization-database-file).
 
 !!! note
-    On the data nodes, the files will actually be owned by Unix user `xrootd` (or other daemon user), not as the user
+    On data nodes, files will be owned by Unix user `xrootd` (or other daemon user), not as the user
     authenticated to, under most circumstances.
     XRootD will verify the permissions and authorization based on the user that the security plugin authenticates you
     to, but, internally, the data node files will be owned by the `xrootd` user. If this behaviour is not desired, enable
     [XRootD multi-user support](install-standalone.md#enabling-multi-user-support). 
 
-Authorization File
-------------------
+Authorization Database File
+---------------------------
 
 XRootD allows configuring fine-grained file access permissions based on usernames and paths.
 This is configured in the authorization file `/etc/xrootd/auth_file` on the data server node, which should be writable
@@ -86,12 +89,16 @@ root@host # chmod 0640 /etc/xrootd/auth_file  # or 0644
 ```
 
 
-LCMAPS Authorization
---------------------
+LCMAPS Authentication
+---------------------
 
-The xrootd-lcmaps security plugin uses the `lcmaps` library and the [LCMAPS VOMS plugin](../../security/lcmaps-voms-authentication.md)
-to authenticate and authorize users based on X509 certificates and VOMS attributes. Perform the following instructions
-on all data nodes:
+!!! info "OSG 3.5 only"
+    LCMAPS-based authentication is only supported in OSG 3.5.
+
+The `xrootd-lcmaps` security plugin uses the LCMAPS library and the
+[LCMAPS VOMS plugin](../../security/lcmaps-voms-authentication.md) to authenticate and authorize users based on X.509
+certificates and VOMS attributes.
+Perform the following instructions on all data nodes:
 
 1. Install [CA certificates](../../common/ca.md#installing-ca-certificates) and [manage CRLs](../../common/ca.md#managing-certificate-revocation-lists)
 
@@ -105,7 +112,7 @@ on all data nodes:
         :::console
         root@host # yum install xrootd-lcmaps vo-client
 
-1. Configure access rights for mapped users by creating and modifying the XRootD [authorization file](#authorization-file)
+1. Configure access rights for mapped users by creating and modifying the XRootD [authorization file](#authorization-database-file)
 
 1. Restart the [relevant services](install-standalone.md#using-xrootd)
 

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -209,7 +209,7 @@ This path is relative to the [`rootdir`](install-standalone.md#configuring-xroot
 
             u * rl /data/xrootdfs -rl /data/xrootdfs/private
 
-    Instead, specify the following to ensure that all users will not be able to read the contents of
+    Instead, specify the following to ensure that a given user will not be able to read the contents of
     `/data/xrootdfs/private` unless specified with another authorization rule:
 
             u * -rl /data/xrootdfs/private rl /data/xrootdfs 

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -28,7 +28,7 @@ in the case of SciTokens and WLCG tokens, you may configure XRootD to further re
 
 ### Configuring SciTokens/WLCG Tokens ###
 
-SciTokens and WLCG Tokens are asymetrically signed bearer tokens: they are signed by a token issuer (e.g., CILogon, IAM)
+SciTokens and WLCG Tokens are asymmetrically signed bearer tokens: they are signed by a token issuer (e.g., CILogon, IAM)
 and can be authenticated with the token issuer's public key.
 To configure XRootD to accept tokens from a given token issuer use the following instructions:
 

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -43,7 +43,7 @@ To configure XRootD to accept tokens from a given token issuer use the following
 
 1.  **(Optional)** if you want to map the incoming token for a given issuer to a Unix username:
 
-    1.  Install [xrootd-multiuser](install-standalone#enabling-multi-user-support)
+    1.  Install [xrootd-multiuser](install-standalone.md#enabling-multi-user-support)
 
     1.  Add the following to the relevant issuer section in `/etc/xrootd/scitokens.conf`:
 

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -3,7 +3,7 @@ DateReviewed: 2021-10-29
 Configuring XRootD Authorization
 ================================
 
-!!!bug "EL7 version compatibility"
+!!!bug "OSG 3.5 EL7 version compatibility"
     There is an incompatibility with EL7 < 7.5 due to an issue with the `globus-gsi-proxy-core` package
 
 XRootD offers several authentication options [security plugins](https://xrootd.slac.stanford.edu/doc/dev50/sec_config.htm)

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -208,12 +208,12 @@ This path is relative to the [`rootdir`](install-standalone.md#configuring-xroot
     Specific paths need to be specified _before_ generic paths.
     For example, this line will allow all users to read the contents `/data/xrootdfs/private`:
 
-            u * rl /data/xrootdfs -rl /data/xrootdfs/private
+            u * /data/xrootdfs rl /data/xrootdfs/private -rl
 
     Instead, specify the following to ensure that a given user will not be able to read the contents of
     `/data/xrootdfs/private` unless specified with another authorization rule:
 
-            u * -rl /data/xrootdfs/private rl /data/xrootdfs 
+            u * /data/xrootdfs/private -rl /data/xrootdfs rl
 
 
 #### Formatting ####


### PR DESCRIPTION
Still to do:

- Clarify how user and group mappings work for LCMAPS, vomsxrd, macaroons, and bearer tokens.
- As @matyasselmeci points out, auth references in other docs: https://github.com/opensciencegrid/docs/pull/890#discussion_r726546209