### PR TITLE
Start of StashCache -> OSDF cleanup.

### DIFF
--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -1,7 +1,7 @@
-Installing the StashCache Cache
-===============================
+Installing the OSDF Cache
+=========================
 
-This document describes how to install a StashCache cache service.  This service allows a site or regional
+This document describes how to install an Open Science Data Federation (OSDF) cache service.  This service allows a site or regional
 network to cache data frequently used on the OSG, reducing data transfer over the wide-area network and
 decreasing access latency.
 
@@ -14,8 +14,8 @@ Before starting the installation process, consider the following requirements:
 * __Operating system:__ A RHEL 7 or compatible operating systems.
 * __User IDs:__ If they do not exist already, the installation will create the Linux user IDs `condor` and
   `xrootd`
-* __Host certificate:__ Required for reporting and authenticated StashCache.
-  Authenticated StashCache is an optional feature.
+* __Host certificate:__ Required for reporting and authenticated caches.
+  Authenticated caching is an optional feature.
   See our [documentation](../../security/host-certs.md) for instructions on how to request and install host certificates.
 * __Network ports:__ The cache service requires the following ports open:
     * Inbound TCP port 1094 for file access via the XRootD protocol
@@ -35,7 +35,7 @@ As with all OSG software installations, there are some one-time steps to prepare
 Registering the Cache
 ---------------------
 
-To be part of the OSG StashCache Federation, your cache must be registered with the OSG.
+To be part of the OSDF, your cache must be registered with the OSG.
 You will need basic information like the resource name and hostname,
 and the administrative and security contacts.
 
@@ -61,27 +61,27 @@ There are extra requirements for serving non-public data:
 
 - In addition to the cache allowing a VO in the `AllowedVOs` list,
   that VO must also allow the cache in its `AllowedCaches` list.
-  See the page on [getting your VO's data into StashCache](vo-data.md).
+  See the page on [getting your VO's data into OSDG](vo-data.md).
 - There must be an authenticated XRootD instance on the cache server.
 - There must be a `DN` attribute in the resource registration
   with the [subject DN](../../security/host-certs/overview.md#before-starting) of the host certificate
 
 This is an example registration for a cache server that serves all public data:
 ```yaml
-  MY_STASHCACHE_CACHE:
+  MY_OSDF_CACHE:
     FQDN: my-cache.example.net
     Service: XRootD cache server
-      Description: StashCache cache server
+      Description: OSDF cache server
     AllowedVOs:
       - ANY_PUBLIC
 ```
 
-This is an example registration for a cache server that only serves authenticated data from the OSG VO:
+This is an example registration for a cache server that only serves authenticated data for the Open Science Pool:
 ```yaml
-  MY_AUTH_STASHCACHE_CACHE:
+  MY_AUTH_OSDF_CACHE:
     FQDN: my-auth-cache.example.net
     Service: XRootD cache server
-      Description: StashCache cache server
+      Description: OSDF cache server
     AllowedVOs:
       - OSG
     DN: /DC=org/DC=opensciencegrid/O=Open Science Grid/OU=Services/CN=my-auth-cache.example.net
@@ -89,10 +89,10 @@ This is an example registration for a cache server that only serves authenticate
 
 This is an example registration for a cache server that serves all public data _and_ authenticated data from the OSG VO:
 ```yaml
-  MY_COMBO_STASHCACHE_CACHE:
+  MY_COMBO_OSDF_CACHE:
     FQDN: my-combo-cache.example.net
     Service: XRootD cache server
-      Description: StashCache cache server
+      Description: OSDF cache server
     AllowedVOs:
       - OSG
       - ANY_PUBLIC
@@ -109,7 +109,7 @@ Mention in your ticket that you would like to "Finalize the cache registration."
 Installing the Cache
 --------------------
 
-The StashCache software consists of an XRootD server with special configuration and supporting services.
+The OSDF software consists of an XRootD server with special configuration and supporting services.
 To simplify installation, OSG provides convenience RPMs that install all required
 packages with a single command:
 
@@ -141,7 +141,7 @@ The mandatory variables to configure are:
 
 ### Ensure the xrootd service has a certificate
 
-The service will need a certificate for reporting and to authenticate to StashCache origins.
+The service will need a certificate for reporting and to authenticate to origins.
 The easiest solution for this is to use your host certificate and key as follows:
 
 1. Copy the host certificate to `/etc/grid-security/xrd/xrd{cert,key}.pem`
@@ -195,7 +195,7 @@ As soon as your issue has been resolved, revert any changes you have made to `/e
 
 ### Enable HTTPS on the unauthenticated cache
 
-By default, the unauthenticated stash-cache instance uses plain HTTP, not HTTPS.
+By default, the unauthenticated cache instance uses plain HTTP, not HTTPS.
 To use HTTPS:
 
 1.  Add a certificate according to the [instructions above](#ensure-the-xrootd-service-has-a-certificate)
@@ -226,7 +226,7 @@ In this case, you must manually tell the cache services which FQDN to use for to
         Environment=CACHE_FQDN=<Topology-registered FQDN>
 
 
-Managing StashCache and associated services
+Managing OSDF services
 -------------------------------------------
 
 These services must be managed by `systemctl` and may start additional services as dependencies.

--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -61,7 +61,7 @@ There are extra requirements for serving non-public data:
 
 - In addition to the cache allowing a VO in the `AllowedVOs` list,
   that VO must also allow the cache in its `AllowedCaches` list.
-  See the page on [getting your VO's data into OSDG](vo-data.md).
+  See the page on [getting your VO's data into OSDF](vo-data.md).
 - There must be an authenticated XRootD instance on the cache server.
 - There must be a `DN` attribute in the resource registration
   with the [subject DN](../../security/host-certs/overview.md#before-starting) of the host certificate

--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -1,14 +1,13 @@
-Installing the StashCache Origin
+Installing the OSDF Origin
 ================================
 
 !!! warning
     If you want to run origins for authenticated and unauthenticated data,
     you **must** run them on separate hosts.
     This requires registering a resource for each host.
-    This requirement will be removed in a future version of StashCache.
 
-This document describes how to install a StashCache origin service.  This service allows an organization
-to export its data to the StashCache data federation.
+This document describes how to install an Open Science Data Federation (OSDF) origin service.  This service allows an organization
+to export its data to the data federation.
 
 !!! note
     The _origin_ must be registered with the OSG prior to joining the data federation. You may start the
@@ -84,7 +83,7 @@ and HCC's registered namespace is `/hcc`, then the following would be set in `10
 
 ```
 set rootdir = /mnt/stash
-set resourcename = HCC_STASH_ORIGIN
+set resourcename = HCC_OSDF_ORIGIN
 ```
 
 And the following would be set in `10-origin-site-local.cfg`:
@@ -92,18 +91,17 @@ And the following would be set in `10-origin-site-local.cfg`:
 set originexport = /hcc
 ```
 
-With this configuration, the data under `/mnt/stash/hcc/bio/datasets` would be available under the StashCache path
-`/hcc/bio/datasets` and the data under `/mnt/stash/hcc/hep/generators` would be available under the StashCache path
-`/hcc/hep/generators`.
+With this configuration, the data under `/mnt/stash/hcc/bio/datasets` would be available under the path
+`/hcc/bio/datasets` in the OSDF namespace and the data under `/mnt/stash/hcc/hep/generators` would be available under the path
+`/hcc/hep/generators` in the OSDF namespace.
 
 !!! warning
     If you want to run origins for authenticated and unauthenticated data,
     you **must** run them on separate hosts.
     This requires registering a resource for each host.
-    This requirement will be removed in a future version of StashCache.
 
 !!! warning
-    The StashCache namespace is *global* within a data federation.
+    The OSDF namespace is a *global* namespace.
     Directories you export **must not** collide with directories provided by other origin servers; this is
     why the explicit registration is required.
 
@@ -218,16 +216,16 @@ Run the following command:
 
 Registering the Origin
 ----------------------
-To be part of the OSG StashCache Federation, your origin must be
+To be part of the Open Science Data Federation, your origin must be
 [registered with the OSG](../../common/registration.md).  The service type is `XRootD origin server`.
 
 The resource must also specify which VOs it will serve data from.
-To do this, add an `AllowedVOs` list, with each line specifying a VO whose StashCache data the resource is willing to host.
+To do this, add an `AllowedVOs` list, with each line specifying a VO whose data the resource is willing to host.
 For example:
 ```yaml
-  MY_STASHCACHE_ORIGIN:
+  MY_OSDF_ORIGIN:
     Service: XRootD origin server
-      Description: StashCache origin server
+      Description: OSDF origin server
     AllowedVOs:
       - GLOW
       - OSG
@@ -236,7 +234,7 @@ You can use the special value `ANY` to indicate that the origin will serve data 
 
 In addition to the origin allowing a VOs via the `AllowedVOs` list,
 that VO must also allow the origin in its `DataFederations/StashCache/AllowedOrigins` list.
-See the page on [getting your VO's data into StashCache](vo-data.md).
+See the page on [getting your VO's data into OSDF](vo-data.md).
 
 Getting Help
 ------------

--- a/docs/data/stashcache/overview.md
+++ b/docs/data/stashcache/overview.md
@@ -1,9 +1,9 @@
-Data Federation Overview
+Open Science Data Federation Overview
 ========================
 
-The OSG operates the _StashCache data federation_, which provides organizations with a method to distribute their data
+The OSG operates the _Open Science Data Federation_ (OSDF), which provides organizations with a method to distribute their data
 in a scalable manner to thousands of jobs without needing to pre-stage data at each site.
-The StashCache data federation is best suited for per-job data set sizes between 1 and 50 GB,
+The OSDF is best suited for per-job data set sizes between 1 and 50 GB,
 with no more than 1 TB for a complete workflow.
 
 Organizations export their data from an _origin server_,
@@ -11,16 +11,16 @@ and the data is streamed to jobs from a set of _cache servers_ distributed throu
 Jobs can achieve lower latency and higher throughput for data transfer by using a nearby cache
 instead of accessing the origin directly.
 
-The map below shows the location of the current caches in the StashCache federation:
+The map below shows the location of the current caches in the federation:
 
-![StashCache Map](StashCacheMap.png "StashCache Map")
+![OSDF Map](StashCacheMap.png "OSDF Map")
 
 ## Architecture
 
-The StashCache federation consists of three service types:
+The OSDF consists of three service types:
 
 * **Origin**: Keeps the authoritative copy of an organization's data.
-    Each origin is operated by the organization that wants to distribute its data within the StashCache federation.
+    Each origin is operated by the organization that wants to distribute its data within the federation.
 * **Cache**: Transfers data to clients such as jobs or users.
     A set of caches are operated across the OSG for the benefit of nearby sites;
     in addition, each site may run its own cache in order to reduce the amount of data transferred over the WAN.
@@ -29,7 +29,7 @@ The StashCache federation consists of three service types:
 
 The structure of the federation is illustrated below:
 
-![StashCache Diagram](StashCache-Diagram.png "StashCache Diagram")
+![OSDF Diagram](StashCache-Diagram.png "OSDF Diagram")
 
 A job will request data from a cache.
 The cache will serve the requested data from local disk if possible.
@@ -38,10 +38,10 @@ download the data from that origin server, and then serve the data to the job.
 A copy of the data will be kept on the cache for use by future jobs.
 
 
-## Joining and Using StashCache
+## Joining and Using the OSDF
 
-* Organizations can export their data to StashCache by [installing the StashCache **Origin**](install-origin.md)
-* Sites can reduce data transfer via the WAN by [installing the StashCache **Cache**](install-cache.md)
-* Users can access StashCache via the
+* Organizations can export their data to the OSDF by [installing the **Origin**](install-origin.md)
+* Sites can reduce data transfer via the WAN by [installing the **Cache**](install-cache.md)
+* Users can access OSDF via the
   [stashcp client](https://support.opensciencegrid.org/support/solutions/articles/12000002775-transferring-data-with-stashcach)
   or from CVMFS via the `/cvmfs/stash.osgstorage.org` directory tree.

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -1,19 +1,19 @@
 DateReviewed: 2020-06-22
 
-Running StashCache Origin in a Container
+Running OSDF Origin in a Container
 ========================================
 
 !!! note
-    Currently, the StashCache Origin container only supports distribution of public data.
+    Currently, the origin container only supports distribution of public data.
     If you would like to distribute private data requiring authentication,
     see [the RPM installation guide](install-origin.md).
 
-The OSG operates the [StashCache data federation](overview.md), which
+The OSG operates the [Open Science Data Federation](overview.md) (OSDF), which
 provides organizations with a method to distribute their data in a scalable manner to thousands of jobs without needing
 to pre-stage data across sites or operate their own scalable infrastructure.
 
-[Stash Origins](install-origin.md) store copies of users' data.
-Each community (or experiment) needs to run one origin to export its data via the StashCache federation.
+[Origins](install-origin.md) store copies of users' data.
+Each community (or experiment) needs to run one origin to export its data via the federation.
 This document outlines how to run such an origin in a Docker container.
 
 Before Starting
@@ -23,9 +23,9 @@ Before starting the installation process, consider the following points:
 
 1. **Docker:** For the purpose of this guide, the host must have a running docker service and you must have the ability
 to start containers (i.e., belong to the `docker` Unix group).
-1. **Network ports:** The Stash Origin listens for incoming HTTP/S and XRootD connections on ports 1094 and 1095 (by
+1. **Network ports:** The origin listens for incoming HTTP/S and XRootD connections on ports 1094 and 1095 (by
 default).
-1. **File Systems:** Stash Origin needs a host partition to store user data.
+1. **File Systems:** The origin needs a host partition to store user data.
 1. **Registration:** Before deploying an origin, you must
    [registered the service](install-origin.md#registering-the-origin) in the OSG Topology
 
@@ -48,7 +48,7 @@ ORIGIN_FQDN=<FQDN>
 Populating Origin Data
 ----------------------
 
-The Stash Cache data federation namespace is shared by multiple VOs so you must
+The OSDF namespace is shared by multiple VOs so you must
 [choose a namespace](vo-data.md#choosing-namespaces) for your own VO's data.
 When running an origin container, your chosen namespace must be reflected in your host partition.
 
@@ -80,7 +80,7 @@ See [this section](#populating-origin-data) for details.
 
 ### Running on origin container with systemd
 
-An example systemd service file for StashCache.
+An example systemd service file for the OSDF.
 This will require creating the environment file in the directory `/opt/origin/.env`.
 
 !!! note
@@ -90,7 +90,7 @@ Create the systemd service file `/etc/systemd/system/docker.stash-origin.service
 
 ```file
 [Unit]
-Description=Stash Origin Container
+Description=Origin Container
 After=docker.service
 Requires=docker.service
 

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -1,16 +1,16 @@
 DateReviewed: 2020-06-22
 
-Running StashCache Cache in a Container
+Running OSDF Cache in a Container
 =======================================
 
-The OSG operates the [StashCache data federation](overview.md), which
+The OSG operates the [Open Science Data Federation](overview.md) (OSDF), which
 provides organizations with a method to distribute their data in a scalable manner to thousands of jobs without needing
 to pre-stage data across sites or operate their own scalable infrastructure.
 
-[Stash Caches](install-cache.md) transfer data to clients such as jobs or users.
+[OSDF Caches](install-cache.md) transfer data to clients such as jobs or users.
 A set of caches are operated across the OSG for the benefit of nearby sites;
 in addition, each site may run its own cache in order to reduce the amount of data transferred over the WAN.
-This document outlines how to run StashCache in a Docker container.
+This document outlines how to run a cache in a Docker container.
 
 Before Starting
 ---------------
@@ -19,12 +19,12 @@ Before starting the installation process, consider the following points:
 
 1. **Docker:** For the purpose of this guide, the host must have a running docker service
    and you must have the ability to start containers (i.e., belong to the `docker` Unix group).
-1. **Network ports:** Stash Cache listens for incoming HTTP/S connections on port 8000 (by default)
-1. **File Systems:** Stash Cache needs host partitions to store user data.
+1. **Network ports:** The cache listens for incoming HTTP/S connections on port 8000 (by default)
+1. **File Systems:** The cache needs host partitions to store user data.
    For improved performance and storage, we recommend multiple partitions for handling namespaces (HDD), data (HDDs),
    and metadata (SSDs).
 
-Configuring Stash Cache
+Configuring the OSDF Cache
 -----------------------
 
 In addition to the required configuration above (ports and file systems),
@@ -57,7 +57,7 @@ Further behavior of the cache can be configured by setting the following in the 
 Running a Cache
 ---------------
 
-StashCache cache containers  may be run with either multiple mounted host partitions (recommended) or a single host
+Cache containers  may be run with either multiple mounted host partitions (recommended) or a single host
 partition.
 
 It is recommended to use a container orchestration service such as [docker-compose](https://docs.docker.com/compose/)
@@ -103,9 +103,9 @@ user@host $ docker run --rm --publish <HOST PORT>:8000 \
              opensciencegrid/stash-cache:release
 ```
 
-### Running Stash Cache on container with systemd
+### Running a cache on container with systemd
 
-An example systemd service file for Stash Cache.
+An example systemd service file for the OSDF cache.
 This will require creating the environment file in the directory `/opt/xcache/.env`. 
 
 !!! note
@@ -115,7 +115,7 @@ Create the systemd service file `/etc/systemd/system/docker.stash-cache.service`
 
 ```file
 [Unit]
-Description=Stash Cache Container
+Description=Cache Container
 After=docker.service
 Requires=docker.service
 

--- a/docs/data/stashcache/vo-data.md
+++ b/docs/data/stashcache/vo-data.md
@@ -1,11 +1,11 @@
-Getting VO Data into StashCache
+Getting VO Data into the OSDF
 ======================================
 
 This document describes the steps required to manage a VO's role
-in the StashCache Data Federation including selecting a namespace, registration,
+in the Open Science Data Federation (OSDF) including selecting a namespace, registration,
 and selecting which resources are allowed to host or cache your data.
 
-For general information about StashCache, see the [overview document](overview.md).
+For general information about the OSDF, see the [overview document](overview.md).
 
 Site admins should work together with VO managers in order to perform these steps.
 
@@ -21,7 +21,7 @@ Definitions
 Requirements
 ------------
 
-In order for a Virtual Organization to join the StashCache Federation, the VO must already be registered in OSG Topology.
+In order for a Virtual Organization to join the federation, the VO must already be registered in OSG Topology.
 See the [registration document](../../common/registration.md#registering-virtual-organizations).
 
 
@@ -33,11 +33,11 @@ The VO must pick one or more "namespaces" for their data.
 A namespace is a directory tree in the federation where VO data is found.
 
 !!! note
-    Namespaces are global across the federation, so you must work with the StashCache Operations team
+    Namespaces are global across the federation, so you must work with the OSG Operations team
     to ensure that your VO's namespaces do not collide with those of another VO.
     
     Send an email to help@opensciencegrid.org with the following subject:
-    "Requesting StashCache namespaces for VO <VO>"
+    "Requesting OSDF namespaces for VO <VO>"
     and put the desired namespaces in the body of the email.
 
 A namespace should be easy for your users to remember but not so generic that it collides with other VOs.
@@ -56,12 +56,12 @@ Separating the public and protected data in separate directory trees is preferre
 Registering Data Federation Information
 ---------------------------------------
 
-The VO must allow one or more StashCache origins to host their data.
+The VO must allow one or more origins to host their data.
 An origin will typically be hosted on a site owned by the VO.
 For information about setting up an origin, see the [installation document](install-origin.md).
 
-In order to declare your VO's role in the StashCache federation,
-you must add StashCache information to your VO's YAML file in the OSG Topology repository.
+In order to declare your VO's role in the federation,
+you must add OSDF information to your VO's YAML file in the OSG Topology repository.
 
 For example, the full registration for the `Astro` VO may look something like the following:
 
@@ -74,7 +74,7 @@ DataFederations:
     AllowedCaches:
       - ANY
     AllowedOrigins:
-      - CHTC_STASHCACHE_ORIGIN
+      - CHTC_OSDF_ORIGIN
 ```
 
 The sections are described below.
@@ -107,7 +107,7 @@ which can only be read by someone with the `/Astro` FQAN or by Matyas Selmeci.
 
 ### AllowedCaches list
 
-The VO must allow one or more StashCache Caches to cache their data.
+The VO must allow one or more OSDF caches to cache their data.
 The more places a VO's data can be cached in, the bigger the data transfer benefit for the VO.
 The majority of caches across OSG will automatically cache all "public" VO data.
 Caching "protected" VO data will often be done on a site owned by the VO.
@@ -126,7 +126,7 @@ There are two cases:
 
 - If you have some protected data, then AllowedCaches is a list of _resources_ that are allowed to cache your data.
    A resource is an entry in a `/topology/<FACILITY>/<SITE>/<RESOURCEGROUP>.yaml` file,
-   for example "CHTC_STASHCACHE_CACHE".
+   for example `CHTC_OSDF_CACHE`.
 
    The following requirements must be met for the resource:
 
@@ -140,7 +140,7 @@ There are two cases:
 AllowedOrigins is a list of which origins are allowed to host your data.
 This is a list of _resources_.
 A resource is an entry in a `/topology/<FACILITY>/<SITE>/<RESOURCEGROUP>.yaml` file,
-for example "CHTC_STASHCACHE_ORIGIN".
+for example `CHTC_OSDF_ORIGIN`.
 
 The following requirements must be met for the resource:
 


### PR DESCRIPTION
This begins the process of cleaning up the use of the word "StashCache" and replacing it with the "OSDF" terminology (which largely mirrors the OSPool terminology and matches the [Glossary](https://path-cc.io/glossary/) we are trying to develop.