### PR TITLE
Fix example XRootD groupname auth for VOMS FQANs

### DIFF
--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -145,7 +145,7 @@ In OSG 3.6, VOMS proxies are automatically mapped using the built-in XRootD GSI 
 An incoming VOMS proxy will authenticate the first VOMS FQAN and map it to an organization name, groupname, and role
 name in the [authorization database](#authorization-database).
 For example, a proxy from the OSPool whose first VOMS FQAN is `/osg/Role=NULL/Capability=NULL` will be authenticated to
-the `osg` groupname.
+the `/osg` groupname.
 
 Instead of only using the first VOMS FQAN, you can configure XRootD to consider all VOMS FQANs in the proxy for
 authentication by setting the following in `/etc/xrootd/config.d/10-osg-xrdvoms.cfg`:


### PR DESCRIPTION
We get it right in the example here https://opensciencegrid.org/docs/data/xrootd/xrootd-authorization/#authorization-database. From Wei:

> XrdVoms maps a typical VOMS attributes 
> 
> VO: atlas   <-- o:
> VO group: /atlas/usatlas <- g:
> 
> You have also have self defined "Special Compound ID"s, for example
> 
> = atlprod o: atlas g: /atlas r: production
> This define "atlprod" as VO "atlas", VO group "/atlas", Role "production"
> 
> x atlprod /xrootd/atlas rwildn
> This define what access privilege "atlprod" has
> 
> The auth file are evaluated in order. The first match will be picked up.