### PR TITLE
Update overview.md

### DIFF
--- a/docs/security/tokens/overview.md
+++ b/docs/security/tokens/overview.md
@@ -180,7 +180,7 @@ These are the collaborations that support or partially support using tokens for 
 
 | Collaboration | Supports Bearer Tokens |
 |:--------------|------------------------|
-| ATLAS         | Undergoing testing     |
+| ATLAS         | yes                    |
 | CLAS12        | Undergoing testing     |
 | CMS           | Undergoing testing     |
 | EIC           | Undergoing testing     |

--- a/docs/security/tokens/overview.md
+++ b/docs/security/tokens/overview.md
@@ -180,7 +180,7 @@ These are the collaborations that support or partially support using tokens for 
 
 | Collaboration | Supports Bearer Tokens |
 |:--------------|------------------------|
-| ATLAS         | yes                    |
+| ATLAS         | Yes                    |
 | CLAS12        | Undergoing testing     |
 | CMS           | Undergoing testing     |
 | EIC           | Undergoing testing     |


### PR DESCRIPTION
With scitokens-cpp >= 0.7.0 extended time for issuer public key caching and our temporary long lifetime access tokens ATLAS is ready to rely exclusively on tokens for job submission.