### PR TITLE
Make page titles match the first header (for xcache and xrootd pages)

### DIFF
--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -1,3 +1,5 @@
+title: Installing the OSDF Cache
+
 Installing the OSDF Cache
 =========================
 

--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -1,3 +1,5 @@
+title: Installing the OSDF Origin
+
 Installing the OSDF Origin
 ================================
 

--- a/docs/data/stashcache/overview.md
+++ b/docs/data/stashcache/overview.md
@@ -1,3 +1,5 @@
+title: Open Science Data Federation Overview
+
 Open Science Data Federation Overview
 ========================
 

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -1,3 +1,4 @@
+title: Running OSDF Origin in a Container
 DateReviewed: 2020-06-22
 
 Running OSDF Origin in a Container

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -1,3 +1,4 @@
+title: Running OSDF Cache in a Container
 DateReviewed: 2020-06-22
 
 Running OSDF Cache in a Container

--- a/docs/data/stashcache/vo-data.md
+++ b/docs/data/stashcache/vo-data.md
@@ -1,3 +1,5 @@
+title: Getting VO Data into the OSDF
+
 Getting VO Data into the OSDF
 ======================================
 

--- a/docs/data/xrootd/install-client.md
+++ b/docs/data/xrootd/install-client.md
@@ -1,3 +1,5 @@
+title: Using XRootD
+
 Using XRootD 
 =============
 

--- a/docs/data/xrootd/install-cms-xcache.md
+++ b/docs/data/xrootd/install-cms-xcache.md
@@ -1,3 +1,5 @@
+title: Installing the CMS XCache
+
 Installing the CMS XCache
 ===============================
 

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -1,3 +1,4 @@
+title: Install XRootD Standalone
 DateReviewed: 2021-11-12
 
 Install XRootD Standalone

--- a/docs/data/xrootd/install-storage-element.md
+++ b/docs/data/xrootd/install-storage-element.md
@@ -1,3 +1,5 @@
+title: Installing an XRootD Storage Element
+
 Installing an XRootD Storage Element
 ====================================
 

--- a/docs/data/xrootd/overview.md
+++ b/docs/data/xrootd/overview.md
@@ -1,3 +1,5 @@
+title: XRootD Overview
+
 XRootD Overview
 ===============
 

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -1,3 +1,4 @@
+title: Configuring XRootD Authorization
 DateReviewed: 2021-11-12
 
 Configuring XRootD Authorization


### PR DESCRIPTION
This overrides the `nav` section of mkdocs.yml.
Otherwise the "Installing the OSDF Cache" page would have the title "Install from RPM",
for example.

I did not do all the pages, this is just a starting point.