### PR TITLE
XRootD/XCache (mostly auth) doc fixups

### DIFF
--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -157,6 +157,8 @@ The easiest solution for this is to use your host certificate and key as follows
 !!! note
     You must repeat the above steps whenever you renew your host certificate.
     If you automate certificate renewal, you should automate copying as well.
+    In addition, you will need to restart the XRootD services (`xrootd@stash-cache` and/or `xrootd@stash-cache-auth`)
+    so they load the updated certificates.
     For example, if you are using Certbot for Let's Encrypt, you should write a "deploy hook" as documented
     [on the Certbot site](https://certbot.eff.org/docs/using.html#renewing-certificates).
 

--- a/docs/data/stashcache/install-cache.md
+++ b/docs/data/stashcache/install-cache.md
@@ -7,6 +7,8 @@ This document describes how to install an Open Science Data Federation (OSDF) ca
 network to cache data frequently used on the OSG, reducing data transfer over the wide-area network and
 decreasing access latency.
 
+!!! note
+    The OSDF cache was previously named "Stash Cache" and some documentation and software may use the old name.
 
 Before Starting
 ---------------

--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -199,7 +199,7 @@ Your server should be marked with a `>+` to indicate that it contains the given 
 
 To verify that you can download a file from the origin server, use the `stashcp` tool.
 Place a `<TEST FILE>` in `<EXPORTED DIR>`. Where `<TEST FILE>` can be any file. The
-`stashcp` tool is available in the `stashcache-client` RPM.
+`stashcp` tool is available in the `stashcp` RPM.
 Run the following command:
 
 ```console

--- a/docs/data/stashcache/install-origin.md
+++ b/docs/data/stashcache/install-origin.md
@@ -12,6 +12,9 @@ This document describes how to install an Open Science Data Federation (OSDF) or
 to export its data to the data federation.
 
 !!! note
+    The OSDF Origin was previously named "Stash Origin" and some documentation and software may use the old name.
+
+!!! note
     The _origin_ must be registered with the OSG prior to joining the data federation. You may start the
     registration process prior to finishing the installation by [using this link](#registering-the-origin) 
     along with information like:

--- a/docs/data/stashcache/run-stash-origin-container.md
+++ b/docs/data/stashcache/run-stash-origin-container.md
@@ -17,6 +17,9 @@ to pre-stage data across sites or operate their own scalable infrastructure.
 Each community (or experiment) needs to run one origin to export its data via the federation.
 This document outlines how to run such an origin in a Docker container.
 
+!!! note
+    The OSDF Origin was previously named "Stash Origin" and some documentation and software may use the old name.
+
 Before Starting
 ---------------
 

--- a/docs/data/stashcache/run-stashcache-container.md
+++ b/docs/data/stashcache/run-stashcache-container.md
@@ -13,6 +13,9 @@ A set of caches are operated across the OSG for the benefit of nearby sites;
 in addition, each site may run its own cache in order to reduce the amount of data transferred over the WAN.
 This document outlines how to run a cache in a Docker container.
 
+!!! note
+    The OSDF cache was previously named "Stash Cache" and some documentation and software may use the old name.
+
 Before Starting
 ---------------
 

--- a/docs/data/xrootd/install-standalone.md
+++ b/docs/data/xrootd/install-standalone.md
@@ -46,13 +46,10 @@ Installing XRootD
 
     Note that OSG 3.5 will reach its end-of-life in [May 2022](../../release/release_series.md#series-overviews).
 
-!!! bug "VOMS attribute mappings incompatible with `xrootd-multiuser` in OSG 3.6"
-    The OSG 3.6 configuration of XRootD uses the `XrdVoms` plugin, which pass along the entire VOMS FQAN as the
-    groupname to the authorization layer (see the section on
-    [authorization database file formatting](xrootd-authorization.md#formatting)).
-    Some characters in VOMS FQANs are not legal in Unix usernames, therefore VOMS attributes mappings are incompatible
-    with `xrootd-multiuser`.
-    See [XRootD GitHub issue #1538](https://github.com/xrootd/xrootd/issues/1538) for more details.
+!!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
+    Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
+    Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
+    If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
 
 !!! bug "Problem interoperating with older origin servers"
     If an XRootD 5.3.4 cache interacts with a 5.1 or 5.2 origin and there is an asyncio error, it may crash the origin.
@@ -149,12 +146,10 @@ For more information, see [the HDFS installation documents](../install-hadoop.md
 
 #### Enabling multi-user support
 
-!!! bug "VOMS attribute mappings incompatible with `xrootd-multiuser` in OSG 3.6"
-    The OSG 3.6 configuration of XRootD uses the `XrdVoms` plugin, which pass along the entire VOMS FQAN as the
-    groupname to the authorization layer (see the section on [authorization database file formatting](xrootd-authorization.md#formatting)).
-    Some characters in VOMS FQANs are not legal in Unix usernames, therefore VOMS attributes mappings are incompatible
-    with `xrootd-multiuser`.
-    See [XRootD GitHub issue #1538](https://github.com/xrootd/xrootd/issues/1538) for more details.
+!!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
+    Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
+    Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
+    If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
 
 The `xrootd-multiuser` plugin allows XRootD to write files on the storage system as the
 [authenticated](xrootd-authorization.md) user instead of the `xrootd` user.

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -91,17 +91,27 @@ Authorizing X.509 proxies
 
 ### Authenticating proxies ###
 
+Authorizations for proxy-based security are declared in an [XRootD authorization database file](#authorization-database).
+XRootD authentication plugins are used to provide the mappings that are used in the database.
+
+Starting with [OSG 3.6](../../release/release_series.md#series-overviews),
+DN mappings are performed with XRootD's built-in GSI support,
+and FQAN mappings are with the XRootD-VOMS (`XrdVoms`) plugin.
+
+To enable proxy authentication, edit `/etc/xrootd/config.d/10-osg-xrdvoms.cfg` and add or uncomment the line
+
+```
+set EnableVoms = 1
+```
+
+!!! note
+    Proxy authentication is already enabled in [XRootD Standalone](install-standalone.md),
+    so this step is not necessary there.
+
 !!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
     Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
     Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
     If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
-
-In [OSG 3.6](../../release/release_series.md#series-overviews), XRootD installations are automatically configured to
-authenticate all X.509 and VOMS proxies, so XRootD administrators can control file access through the
-[authorization database](#authorization-database).
-Optionally, you may map the subject distinguished names of incoming X.509 proxies to a username in
-`/etc/grid-security/grid-mapfile`.
-This mapped username can then be used in XRootD's authorization database file.
 
 #### Mapping subject DNs ####
 

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -4,9 +4,6 @@ DateReviewed: 2021-11-12
 Configuring XRootD Authorization
 ================================
 
-!!!bug "OSG 3.5 EL7 version compatibility"
-    There is an incompatibility with EL7 < 7.5 due to an issue with the `globus-gsi-proxy-core` package
-
 XRootD offers several authentication options [security plugins](https://xrootd.slac.stanford.edu/doc/dev50/sec_config.htm)
 to validate incoming credentials, such as bearer tokens, X.509 proxies, and VOMS proxies.
 

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -94,12 +94,10 @@ Authorizing X.509 proxies
 
 ### Authenticating proxies ###
 
-!!! bug "VOMS attribute mappings incompatible with `xrootd-multiuser`"
-    The OSG 3.6 configuration of XRootD uses the `XrdVoms` plugin, which pass along the entire VOMS FQAN as the
-    groupname to the authorization layer (see the section on [authorization database file formatting](#formatting)).
-    Some characters in VOMS FQANs are not legal in Unix usernames, therefore VOMS attributes mappings are incompatible
-    with `xrootd-multiuser`.
-    See [XRootD GitHub issue #1538](https://github.com/xrootd/xrootd/issues/1538) for more details.
+!!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
+    Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
+    Support for this is expected in xrootd-voms 5.5.0 and is available in xrootd-voms 5.4.2-1.1, in the OSG 3.6 repos.
+    If you want to use multiuser, ensure you are getting xrootd-voms from the OSG repos.
 
 In [OSG 3.6](../../release/release_series.md#series-overviews), XRootD installations are automatically configured to
 authenticate all X.509 and VOMS proxies, so XRootD administrators can control file access through the
@@ -135,12 +133,10 @@ i.e. authorize access to clients presenting the above proxy with `u blin ...` in
 
 #### Mapping VOMS attributes ####
 
-!!! bug "VOMS attribute mappings incompatible with `xrootd-multiuser`"
-    The OSG 3.6 configuration of XRootD uses the `XrdVoms` plugin, which pass along the entire VOMS FQAN as the
-    groupname to the authorization layer (see the section on [authorization database formatting](#formatting)).
-    Some characters in VOMS FQANs are not legal in Unix usernames, therefore VOMS attributes mappings are incompatible
-    with `xrootd-multiuser`.
-    See [XRootD GitHub issue #1538](https://github.com/xrootd/xrootd/issues/1538) for more details.
+!!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
+    Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
+    Support for this is expected in xrootd-voms 5.5.0 and is available in xrootd-voms 5.4.2-1.1, in the OSG 3.6 repos.
+    If you want to use multiuser, ensure you are getting xrootd-voms from the OSG repos.
 
 In OSG 3.6, VOMS proxies are automatically mapped using the built-in XRootD GSI and VOMS plug-ins.
 An incoming VOMS proxy will authenticate the first VOMS FQAN and map it to an organization name, groupname, and role

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -113,6 +113,11 @@ set EnableVoms = 1
     Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
     If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
 
+!!! warning "Key length requirements"
+    Servers on EL 8 or newer will reject proxies that are not at least 2048 bits long.
+    Ensure your clients' proxies have at least 2048 bits long with `voms-proxy-info`;
+    if necessary, have them add the argument `-bits 2048` to their `voms-proxy-init` calls.
+
 #### Mapping subject DNs ####
 
 !!! note "DN mappings take precedence over VOMS attributes"

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -162,6 +162,27 @@ set vomsfqans = useall
 
 <!-- XXX and how does this work? How can multiple FQANs be used? -->
 
+
+#### Mapping VOMS attributes to users ####
+
+In order for the XRootD-Multiuser plugin to work, a proxy must be mapped to a user (`u`) that is a valid Unix user.
+Use a VOMS Mapfile in `/etc/grid-security/voms-mapfile` that contains lines in the following form:
+```
+"<FQAN PATTERN>" <USERNAME>
+```
+replacing `<FQAN PATTERN>` with a glob matching FQANs, and `<USERNAME>` with the user that you want to map
+matching FQANs to.
+
+For example,
+```
+"/osg/*" osg01
+```
+will map FQANs starting with `/osg/` to the user `osg01`.
+
+See the [VOMS Mapping documentation](https://github.com/xrootd/xrootd/tree/master/src/XrdVoms#voms-mapping) for details.
+VOMS Mapfiles used with LCMAPS should continue to work unmodified.
+
+
 ### Authenticating Proxies (deprecated) ###
 
 !!! info "OSG 3.5 end-of-life"

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -93,8 +93,8 @@ Authorizing X.509 proxies
 
 !!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
     Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
-    Support for this is expected in xrootd-voms 5.5.0 and is available in xrootd-voms 5.4.2-1.1, in the OSG 3.6 repos.
-    If you want to use multiuser, ensure you are getting xrootd-voms from the OSG repos.
+    Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
+    If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
 
 In [OSG 3.6](../../release/release_series.md#series-overviews), XRootD installations are automatically configured to
 authenticate all X.509 and VOMS proxies, so XRootD administrators can control file access through the
@@ -132,8 +132,8 @@ i.e. authorize access to clients presenting the above proxy with `u blin ...` in
 
 !!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
     Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
-    Support for this is expected in xrootd-voms 5.5.0 and is available in xrootd-voms 5.4.2-1.1, in the OSG 3.6 repos.
-    If you want to use multiuser, ensure you are getting xrootd-voms from the OSG repos.
+    Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
+    If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
 
 In OSG 3.6, VOMS proxies are automatically mapped using the built-in XRootD GSI and VOMS plug-ins.
 An incoming VOMS proxy will authenticate the first VOMS FQAN and map it to an organization name, groupname, and role

--- a/docs/data/xrootd/xrootd-authorization.md
+++ b/docs/data/xrootd/xrootd-authorization.md
@@ -145,11 +145,13 @@ i.e. authorize access to clients presenting the above proxy with `u blin ...` in
     Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
     If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
 
-In OSG 3.6, VOMS proxies are automatically mapped using the built-in XRootD GSI and VOMS plug-ins.
-An incoming VOMS proxy will authenticate the first VOMS FQAN and map it to an organization name, groupname, and role
-name in the [authorization database](#authorization-database).
+In OSG 3.6, if the XRootD-VOMS plugin is enabled,
+an incoming VOMS proxy will authenticate the first VOMS FQAN and map it to an organization name (`o`),
+groupname (`g`), and role name (`r`) in the [authorization database](#authorization-database).
 For example, a proxy from the OSPool whose first VOMS FQAN is `/osg/Role=NULL/Capability=NULL` will be authenticated to
-the `/osg` groupname.
+the `/osg` groupname; note that the `/` _is_ included in the groupname.
+
+<!-- XXX Which part of an FQAN ends up in "organization" ? -->
 
 Instead of only using the first VOMS FQAN, you can configure XRootD to consider all VOMS FQANs in the proxy for
 authentication by setting the following in `/etc/xrootd/config.d/10-osg-xrdvoms.cfg`:
@@ -157,6 +159,8 @@ authentication by setting the following in `/etc/xrootd/config.d/10-osg-xrdvoms.
 ```
 set vomsfqans = useall
 ```
+
+<!-- XXX and how does this work? How can multiple FQANs be used? -->
 
 ### Authenticating Proxies (deprecated) ###
 

--- a/docs/release/updating-to-osg-36.md
+++ b/docs/release/updating-to-osg-36.md
@@ -352,13 +352,10 @@ Replacing Your GridFTP Service
     If your collaboration(s) don't support these new protocols, install or remain on the
     [OSG 3.5 release series, with the osg-upcoming repositories enabled](notes.md).
 
-!!! bug "VOMS attribute mappings incompatible with `xrootd-multiuser` in OSG 3.6"
-    The OSG 3.6 configuration of XRootD uses the `XrdVoms` plugin, which pass along the entire VOMS FQAN as the
-    groupname to the authorization layer (see the section on
-    [authorization database file formatting](../data/xrootd/xrootd-authorization.md#formatting)).
-    Some characters in VOMS FQANs are not legal in Unix usernames, therefore VOMS attributes mappings are incompatible
-    with `xrootd-multiuser`.
-    See [XRootD GitHub issue #1538](https://github.com/xrootd/xrootd/issues/1538) for more details.
+!!! warning "Requirements for XRootD-Multiuser with VOMS FQANs"
+    Using XRootD-Multiuser with a VOMS FQAN requires mapping the FQAN to a username, which requires a `voms-mapfile`.
+    Support is available in `xrootd-voms 5.4.2-1.1`, in the OSG 3.6 repos, though it is expected in XRootD 5.5.0.
+    If you want to use multiuser, ensure you are getting `xrootd-voms` from the OSG repos.
 
 As part of the [GridFTP and GSI migration](https://opensciencegrid.org/technology/policy/gridftp-gsi-migration/),
 GridFTP is no longer available in the OSG 3.6 repositories.


### PR DESCRIPTION
These are fixes to the xrootd auth docs that I found while doing [SOFTWARE-5109](https://opensciencegrid.atlassian.net/browse/SOFTWARE-5109) that I think ought to go in before I can write docs on upgrading caches.