### PR TITLE
Update the Stashcache Overview Page

### DIFF
--- a/docs/data/stashcache/overview.md
+++ b/docs/data/stashcache/overview.md
@@ -15,13 +15,15 @@ We support three types of deployments:
 
 1. We operate the service for you. All you need is provide us with a K8S host to deploy our container into.
    
-    This is our preferred way for you to join. It is conceptually described on our [home website](https://osg-htc.org/about/osdf/deploying_an_osdf_origin.html) for an origin. A cache would be deployed exactly the same way.
+    This is our preferred way for you to join.
+    It is conceptually described on our [home website](https://osg-htc.org/about/osdf/deploying_an_osdf_origin.html) for an origin.
+    A cache would be deployed exactly the same way.
 
     If this is how you want to join OSDF, please send email to <support@opensciencegrid.org> and we will guide you through the process.
    
-2. You can deploy our container yourself as described in our [documentation](https://opensciencegrid.org/docs/data/stashcache/run-stashcache-container/).
+1. You can deploy our container yourself as described in our [documentation](run-stashcache-container.md).
    
-3. You can deploy from RPM as described in our [documentation](https://opensciencegrid.org/docs/data/stashcache/install-cache/)
+1. You can deploy from RPM as described in our [documentation](install-cache.md)
 
 We strongly suggest that you __allow us to operate these services for you__. The software that implements the service 
 changes frequently enough, and is complicated enough, that keeping up with changes requires significant effort. As you fall 

--- a/docs/data/stashcache/overview.md
+++ b/docs/data/stashcache/overview.md
@@ -13,7 +13,7 @@ The map below shows the location of the current caches in the federation:
 
 We support three types of deployments:
 
-1. We operate the service for you. All you need is provide us with a K8S host to deploy our container into.
+1. We operate the service for you. All you need is provide us with a Kubernetes host to deploy our container into.
    
     This is our preferred way for you to join.
     It is conceptually described on our [home website](https://osg-htc.org/about/osdf/deploying_an_osdf_origin.html) for an origin.
@@ -25,12 +25,10 @@ We support three types of deployments:
    
 1. You can deploy from RPM as described in our [documentation](install-cache.md)
 
-We strongly suggest that you __allow us to operate these services for you__. The software that implements the service 
-changes frequently enough, and is complicated enough, that keeping up with changes requires significant effort. As you fall 
-behind with what you installed, we are likely to eliminate you from the OSDF for operational and/or security reasons.
+We strongly suggest that you __allow us to operate these services for you (option 1)__. 
+The software that implements the service changes frequently enough, and is complicated enough, that keeping up with changes may require significant effort.
+If your installation is deemed too out-of-date, your service may be excluded from the OSDF.
 
-Why put all the effort into learning how to install and operate these services unless you are committed to keeping up with 
-the changes? You are much better off letting our experts deploy and operate these services for you.
 
 __For more information on the OSDF__, please see our [overview page](https://osg-htc.org/about/osdf/).
 

--- a/docs/data/stashcache/overview.md
+++ b/docs/data/stashcache/overview.md
@@ -3,47 +3,33 @@ title: Open Science Data Federation Overview
 Open Science Data Federation Overview
 ========================
 
-The OSG operates the _Open Science Data Federation_ (OSDF), which provides organizations with a method to distribute their data
-in a scalable manner to thousands of jobs without needing to pre-stage data at each site.
-The OSDF is best suited for per-job data set sizes between 1 and 50 GB,
-with no more than 1 TB for a complete workflow.
-
-Organizations export their data from an _origin server_,
-and the data is streamed to jobs from a set of _cache servers_ distributed throughout the OSG and Internet2.
-Jobs can achieve lower latency and higher throughput for data transfer by using a nearby cache
-instead of accessing the origin directly.
+The OSG operates the Open Science Data Federation (OSDF), which provides organizations with a method to distribute their data in a scalable manner to thousands of jobs without needing to pre-stage data at each site.
 
 The map below shows the location of the current caches in the federation:
 
-![OSDF Map](StashCacheMap.png "OSDF Map")
-
-## Architecture
-
-The OSDF consists of three service types:
-
-* **Origin**: Keeps the authoritative copy of an organization's data.
-    Each origin is operated by the organization that wants to distribute its data within the federation.
-* **Cache**: Transfers data to clients such as jobs or users.
-    A set of caches are operated across the OSG for the benefit of nearby sites;
-    in addition, each site may run its own cache in order to reduce the amount of data transferred over the WAN.
-* **Redirector**: Tells a cache service which origin to download data from.
-    The redirectors are run centrally by OSG Operations.
-
-The structure of the federation is illustrated below:
-
-![OSDF Diagram](StashCache-Diagram.png "OSDF Diagram")
-
-A job will request data from a cache.
-The cache will serve the requested data from local disk if possible.
-Otherwise, it will query a redirector for the origin server that provides the data,
-download the data from that origin server, and then serve the data to the job.
-A copy of the data will be kept on the cache for use by future jobs.
-
+<iframe width="100%" height="500px" frameBorder="0" style="margin-bottom:1em; margin-top:1em" src="https://map.opensciencegrid.org/map/iframe?view=XRootD#38.61687,-97.86621|4|hybrid"></iframe>
 
 ## Joining and Using the OSDF
 
-* Organizations can export their data to the OSDF by [installing the **Origin**](install-origin.md)
-* Sites can reduce data transfer via the WAN by [installing the **Cache**](install-cache.md)
-* Users can access OSDF via the
-  [stashcp client](https://support.opensciencegrid.org/support/solutions/articles/12000002775-transferring-data-with-stashcach)
-  or from CVMFS via the `/cvmfs/stash.osgstorage.org` directory tree.
+We support three types of deployments:
+
+1. We operate the service for you. All you need is provide us with a K8S host to deploy our container into.
+   
+    This is our preferred way for you to join. It is conceptually described on our [home website](https://osg-htc.org/about/osdf/deploying_an_osdf_origin.html) for an origin. A cache would be deployed exactly the same way.
+
+    If this is how you want to join OSDF, please send email to <support@opensciencegrid.org> and we will guide you through the process.
+   
+2. You can deploy our container yourself as described in our [documentation](https://opensciencegrid.org/docs/data/stashcache/run-stashcache-container/).
+   
+3. You can deploy from RPM as described in our [documentation](https://opensciencegrid.org/docs/data/stashcache/install-cache/)
+
+We strongly suggest that you __allow us to operate these services for you__. The software that implements the service 
+changes frequently enough, and is complicated enough, that keeping up with changes requires significant effort. As you fall 
+behind with what you installed, we are likely to eliminate you from the OSDF for operational and/or security reasons.
+
+Why put all the effort into learning how to install and operate these services unless you are committed to keeping up with 
+the changes? You are much better off letting our experts deploy and operate these services for you.
+
+__For more information on the OSDF__, please see our [overview page](https://osg-htc.org/about/osdf/).
+
+


### PR DESCRIPTION
This rectifies conflicts that exist between the current https://osg-htc.org/about/osdf and https://opensciencegrid.org/docs/data/stashcache/overview/

It contains a union of suggestions by @bbockelm and Frank W.